### PR TITLE
fix: avoid overriding component properties not specified in props

### DIFF
--- a/src/utils/createComponentWithOrderedProps.ts
+++ b/src/utils/createComponentWithOrderedProps.ts
@@ -14,9 +14,8 @@ export default function createComponentWithOrderedProps<P extends {}, E extends 
     }
 
     for (const name of names) {
-      const propValue = props[name];
-      if (propValue !== undefined) {
-        orderedProps[name] = propValue;
+      if (props.hasOwnProperty(name)) {
+        orderedProps[name] = props[name];
       }
     }
 

--- a/src/utils/createComponentWithOrderedProps.ts
+++ b/src/utils/createComponentWithOrderedProps.ts
@@ -14,7 +14,10 @@ export default function createComponentWithOrderedProps<P extends {}, E extends 
     }
 
     for (const name of names) {
-      orderedProps[name] = props[name];
+      const propValue = props[name];
+      if (propValue !== undefined) {
+        orderedProps[name] = propValue;
+      }
     }
 
     orderedProps.ref = ref;

--- a/test/DateTimePicker.spec.tsx
+++ b/test/DateTimePicker.spec.tsx
@@ -17,4 +17,16 @@ describe('DatePicker', () => {
 
     expect(element).to.have.value(value);
   });
+
+  it('should not override value set on DOM element on rerender', () => {
+    const { container, rerender } = render(<DateTimePicker label="Foo" />);
+
+    const element = container.querySelector('vaadin-date-time-picker');
+    expect(element).to.exist;
+    element!.value = '2020-01-01T15:00';
+    expect(element).to.have.value('2020-01-01T15:00');
+
+    rerender(<DateTimePicker label="Foo" />);
+    expect(element).to.have.value('2020-01-01T15:00');
+  });
 });


### PR DESCRIPTION
## Description

Fixes `createComponentWithOrderedProps` to only define props that were actually provided in the original props object.

Fixes https://github.com/vaadin/hilla/issues/1545