### PR TITLE
fix: add return types to forwardRef for IntelliJ completion

### DIFF
--- a/src/ContextMenu.tsx
+++ b/src/ContextMenu.tsx
@@ -1,4 +1,4 @@
-import { type ComponentType, type ForwardedRef, forwardRef, type ReactElement } from 'react';
+import { type ComponentType, type ForwardedRef, forwardRef, type ReactElement, type RefAttributes } from 'react';
 import {
   ContextMenu as _ContextMenu,
   type ContextMenuRendererContext,
@@ -30,6 +30,8 @@ function ContextMenu(props: ContextMenuProps, ref: ForwardedRef<ContextMenuEleme
   );
 }
 
-const ForwardedContextMenu = forwardRef(ContextMenu);
+const ForwardedContextMenu = forwardRef(ContextMenu) as (
+  props: ContextMenuProps & RefAttributes<ContextMenuElement>,
+) => ReactElement | null;
 
 export { ForwardedContextMenu as ContextMenu };

--- a/src/DateTimePicker.tsx
+++ b/src/DateTimePicker.tsx
@@ -1,13 +1,19 @@
-import { forwardRef } from 'react';
+import { forwardRef, type ReactElement, type RefAttributes } from 'react';
 import {
   DateTimePicker as _DateTimePicker,
   type DateTimePickerElement,
-  type DateTimePickerProps,
+  type DateTimePickerProps as _DateTimePickerProps,
 } from './generated/DateTimePicker.js';
 import createComponentWithOrderedProps from './utils/createComponentWithOrderedProps.js';
 
 export * from './generated/DateTimePicker.js';
 
-export const DateTimePicker = forwardRef(
+type KeysStartingWith<Set, Needle extends string> = Set extends `${Needle}${infer _X}` ? Set : never;
+
+type DateTimePickerProps = Omit<_DateTimePickerProps, KeysStartingWith<keyof _DateTimePickerProps, '_'>>;
+
+const ForwardedDateTimePicker = forwardRef(
   createComponentWithOrderedProps<DateTimePickerProps, DateTimePickerElement>(_DateTimePicker, 'value'),
-);
+) as (props: DateTimePickerProps & RefAttributes<DateTimePickerElement>) => ReactElement | null;
+
+export { ForwardedDateTimePicker as DateTimePicker };

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,4 +1,11 @@
-import { type ComponentType, type ForwardedRef, forwardRef, type ReactElement, type ReactNode } from 'react';
+import {
+  type ComponentType,
+  type ForwardedRef,
+  forwardRef,
+  type ReactElement,
+  type ReactNode,
+  type RefAttributes,
+} from 'react';
 import { Dialog as _Dialog, type DialogElement, type DialogProps as _DialogProps } from './generated/Dialog.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
 import type { ReactSimpleRendererProps } from './renderers/useSimpleRenderer.js';
@@ -34,6 +41,8 @@ function Dialog(
   );
 }
 
-const ForwardedDialog = forwardRef(Dialog);
+const ForwardedDialog = forwardRef(Dialog) as (
+  props: DialogProps & RefAttributes<DialogElement>,
+) => ReactElement | null;
 
 export { ForwardedDialog as Dialog };

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   type ReactElement,
   type ReactNode,
+  type RefAttributes,
   useEffect,
   useRef,
 } from 'react';
@@ -16,7 +17,11 @@ export * from './generated/Select.js';
 
 export type SelectReactRendererProps = ReactSimpleRendererProps<SelectElement>;
 
-export type SelectProps = Partial<Omit<_SelectProps, 'children' | 'renderer'>> &
+type KeysStartingWith<Set, Needle extends string> = Set extends `${Needle}${infer _X}` ? Set : never;
+
+export type SelectProps = Partial<
+  Omit<_SelectProps, 'children' | 'renderer' | KeysStartingWith<keyof _SelectProps, '_'>>
+> &
   Readonly<{
     children?: ReactNode | ComponentType<SelectReactRendererProps>;
     renderer?: ComponentType<SelectReactRendererProps> | null;
@@ -40,6 +45,8 @@ function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElem
   );
 }
 
-const ForwardedSelect = forwardRef(Select);
+const ForwardedSelect = forwardRef(Select) as (
+  props: SelectProps & RefAttributes<SelectElement>,
+) => ReactElement | null;
 
 export { ForwardedSelect as Select };

--- a/src/TimePicker.tsx
+++ b/src/TimePicker.tsx
@@ -1,9 +1,19 @@
-import { forwardRef } from 'react';
-import { TimePicker as _TimePicker, type TimePickerElement, type TimePickerProps } from './generated/TimePicker.js';
+import { forwardRef, type ReactElement, type RefAttributes } from 'react';
+import {
+  TimePicker as _TimePicker,
+  type TimePickerElement,
+  type TimePickerProps as _TimePickerProps,
+} from './generated/TimePicker.js';
 import createComponentWithOrderedProps from './utils/createComponentWithOrderedProps.js';
 
 export * from './generated/TimePicker.js';
 
-export const TimePicker = forwardRef(
+type KeysStartingWith<Set, Needle extends string> = Set extends `${Needle}${infer _X}` ? Set : never;
+
+type TimePickerProps = Omit<_TimePickerProps, KeysStartingWith<keyof _TimePickerProps, '_'>>;
+
+const ForwardedTimePicker = forwardRef(
   createComponentWithOrderedProps<TimePickerProps, TimePickerElement>(_TimePicker, 'value'),
-);
+) as (props: TimePickerProps & RefAttributes<TimePickerElement>) => ReactElement | null;
+
+export { ForwardedTimePicker as TimePicker };


### PR DESCRIPTION
## Description

Fixes #165

Added type cast to components using `forwardRef` similar to how it's done in other cases, especially `Notification` and components with generics e.g. `Grid`. This is a workaround for the [IntelliJ bug](https://youtrack.jetbrains.com/issue/WEB-46192/React-Components-not-detected-using-ForwardRefExoticComponent) related to `ForwardRefExoticComponent`.

Note: I also had to add special helper to omit properties starting with underscore using [TS template literal types](https://stackoverflow.com/a/73191084/6694206).
Otherwise, code completion popup for `DateTimePicker`, `Select` and `TimePicker` would look like this:

<img width="647" alt="Screenshot 2023-12-08 at 10 22 53" src="https://github.com/vaadin/react-components/assets/10589913/16191be1-aa63-4107-8823-104aa570172e">

There is no need to use this for `ContextMenu` and `Dialog` as they don't expose protected properties.

## Type of change

- Bugfix