### PR TITLE
refactor!: exclude clutter from the component API

### DIFF
--- a/src/utils/createComponent.ts
+++ b/src/utils/createComponent.ts
@@ -76,14 +76,14 @@ type NarrowedWebComponentProps<I extends HTMLElement, E extends EventNames = {}>
 // supported by Grid column element and `ariaLabel` doesn't necessarily work as expected for all components.
 type SharedWebComponentProps<I extends HTMLElement> = Pick<
   AllWebComponentProps<I>,
-  'children' | 'id' | 'slot' | 'title' | 'style' | 'className' | 'hidden' | 'ariaLabel'
+  'ariaLabel'
 >;
 
 export type WebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
   AllWebComponentProps<I, E>,
   keyof HTMLElement
-> &
-  SharedWebComponentProps<I>;
+> & React.HTMLAttributes<I> &
+  SharedWebComponentProps<I>
 
 // We need a separate declaration here; otherwise, the TypeScript fails into the
 // endless loop trying to resolve the typings.

--- a/src/utils/createComponent.ts
+++ b/src/utils/createComponent.ts
@@ -59,9 +59,31 @@ export type ThemedWebComponentProps<
   theme?: string;
 };
 
-export type WebComponentProps<I extends HTMLElement, E extends EventNames = {}> = I extends ThemePropertyMixinClass
+type AllWebComponentProps<I extends HTMLElement, E extends EventNames = {}> = I extends ThemePropertyMixinClass
   ? ThemedWebComponentProps<I, E>
   : _WebComponentProps<I, E>;
+
+// Omit properties that are defined on the HTMLElement.
+// TODO: If this type is used with WebComponentProps, for some reason the generated files under /generated would
+// get bloated with derived properties. Investiage.
+type NarrowedWebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
+  AllWebComponentProps<I, E>,
+  keyof HTMLElement
+>;
+
+// Pick properties that should be supported by all components.
+// TODO: We probably don't want to expose all these properties on every component. For example, `style` is not
+// supported by Grid column element and `ariaLabel` doesn't necessarily work as expected for all components.
+type SharedWebComponentProps<I extends HTMLElement> = Pick<
+  AllWebComponentProps<I>,
+  'children' | 'id' | 'slot' | 'title' | 'style' | 'className' | 'hidden' | 'ariaLabel'
+>;
+
+export type WebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
+  AllWebComponentProps<I, E>,
+  keyof HTMLElement
+> &
+  SharedWebComponentProps<I>;
 
 // We need a separate declaration here; otherwise, the TypeScript fails into the
 // endless loop trying to resolve the typings.

--- a/src/utils/createComponent.ts
+++ b/src/utils/createComponent.ts
@@ -6,6 +6,7 @@ import {
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type React from 'react';
 import type { RefAttributes } from 'react';
+import type { ControllerMixinClass } from '@vaadin/component-base/src/controller-mixin.js';
 
 declare const __VERSION__: string;
 
@@ -72,8 +73,7 @@ type NarrowedWebComponentProps<I extends HTMLElement, E extends EventNames = {}>
 >;
 
 // Pick properties that should be supported by all components.
-// TODO: We probably don't want to expose all these properties on every component. For example, `style` is not
-// supported by Grid column element and `ariaLabel` doesn't necessarily work as expected for all components.
+// TODO: `ariaLabel` doesn't necessarily work as expected for all components.
 type SharedWebComponentProps<I extends HTMLElement> = Pick<
   AllWebComponentProps<I>,
   'ariaLabel'
@@ -81,7 +81,7 @@ type SharedWebComponentProps<I extends HTMLElement> = Pick<
 
 export type WebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
   AllWebComponentProps<I, E>,
-  keyof HTMLElement
+  keyof HTMLElement | keyof ControllerMixinClass
 > & React.HTMLAttributes<I> &
   SharedWebComponentProps<I>
 

--- a/src/utils/createComponent.ts
+++ b/src/utils/createComponent.ts
@@ -64,32 +64,18 @@ type AllWebComponentProps<I extends HTMLElement, E extends EventNames = {}> = I 
   ? ThemedWebComponentProps<I, E>
   : _WebComponentProps<I, E>;
 
-// Omit properties that are defined on the HTMLElement.
-// TODO: If this type is used with WebComponentProps, for some reason the generated files under /generated would
-// get bloated with derived properties. Investiage.
-type NarrowedWebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
-  AllWebComponentProps<I, E>,
-  keyof HTMLElement
->;
-
-// Pick properties that should be supported by all components.
-// TODO: `ariaLabel` doesn't necessarily work as expected for all components.
-type SharedWebComponentProps<I extends HTMLElement> = Pick<
-  AllWebComponentProps<I>,
-  'ariaLabel'
->;
-
 export type WebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
   AllWebComponentProps<I, E>,
   keyof HTMLElement | keyof ControllerMixinClass
-> & React.HTMLAttributes<I> &
-  SharedWebComponentProps<I>
+> &
+  React.HTMLAttributes<I>;
 
 // We need a separate declaration here; otherwise, the TypeScript fails into the
 // endless loop trying to resolve the typings.
 export function createComponent<I extends HTMLElement, E extends EventNames = {}>(
   options: Options<I, E>,
 ): (props: WebComponentProps<I, E> & RefAttributes<I>) => React.ReactElement | null;
+
 export function createComponent<I extends HTMLElement, E extends EventNames = {}>(options: Options<I, E>): any {
   const { elementClass } = options;
 

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,7 +1,8 @@
-import React, { type AriaAttributes, type CSSProperties } from 'react';
-import { TextField } from '../src/TextField.js';
+import React, { type HTMLAttributes } from 'react';
+import { TextField, TextFieldElement } from '../src/TextField.js';
 import type { LitElement } from 'lit';
-import { GridColumn } from '../src/GridColumn.js';
+import { GridColumn, GridColumnElement } from '../src/GridColumn.js';
+import { Dialog, DialogElement } from '../src/Dialog.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
@@ -9,21 +10,27 @@ const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
 const textFieldProps = React.createElement(TextField, {}).props;
 type TextFieldProps = typeof textFieldProps;
 
+type PartialTextFieldElement = Omit<Partial<TextFieldElement>, 'draggable' | 'style' | 'translate' | 'children' | 'contentEditable'>;
+
+assertType<PartialTextFieldElement>(textFieldProps);
+
 // Assert that certain properties are present
-assertType<string | null | undefined>(textFieldProps.label);
-assertType<boolean | undefined>(textFieldProps.hidden);
-assertType<CSSProperties | undefined>(textFieldProps.style);
-assertType<string | undefined>(textFieldProps.className);
-assertType<string | undefined>(textFieldProps.slot);
-assertType<string | undefined>(textFieldProps.title);
-assertType<string | undefined>(textFieldProps.id);
-assertType<React.ReactNode>(textFieldProps.children);
-assertType<ARIAMixin['ariaLabel'] | undefined>(textFieldProps.ariaLabel);
-assertType<AriaAttributes['aria-label'] | undefined>(textFieldProps['aria-label']);
+assertType<PartialTextFieldElement['label']>(textFieldProps.label);
+assertType<PartialTextFieldElement['value']>(textFieldProps.value);
+assertType<PartialTextFieldElement['hidden']>(textFieldProps.hidden);
+assertType<PartialTextFieldElement['slot']>(textFieldProps.slot);
+assertType<PartialTextFieldElement['title']>(textFieldProps.title);
+assertType<PartialTextFieldElement['id']>(textFieldProps.id);
+
+assertType<HTMLAttributes<TextFieldElement>['className']>(textFieldProps.className);
+assertType<HTMLAttributes<TextFieldElement>['style']>(textFieldProps.style);
+assertType<HTMLAttributes<TextFieldElement>['children']>(textFieldProps.children);
+assertType<HTMLAttributes<TextFieldElement>['aria-label']>(textFieldProps['aria-label']);
 
 // Assert that certain HTMLElement properties are NOT present
 assertOmitted<HTMLElement, TextFieldProps>('append');
 assertOmitted<HTMLElement, TextFieldProps>('prepend');
+assertOmitted<HTMLElement, TextFieldProps>('ariaLabel');
 
 // Assert that certain LitElement properties are NOT present
 assertOmitted<LitElement, TextFieldProps>('renderRoot');
@@ -33,4 +40,8 @@ assertOmitted<LitElement, TextFieldProps>('removeController');
 
 const gridColumnProps = React.createElement(GridColumn, {}).props;
 // TODO: This should come from the GridColumn API, not from HTMLAttributes
-assertType<boolean | undefined>(gridColumnProps.hidden);
+assertType<GridColumnElement['hidden'] | undefined>(gridColumnProps.hidden);
+
+const dialogProps = React.createElement(Dialog, {}).props;
+
+assertType<DialogElement['ariaLabel'] | undefined>(dialogProps.ariaLabel);

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -4,8 +4,10 @@ import type { LitElement } from 'lit';
 import { GridColumn } from '../src/GridColumn.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
+const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
 
 const textFieldProps = React.createElement(TextField, {}).props;
+type TextFieldProps = typeof textFieldProps;
 
 // Assert that certain properties are present
 assertType<string | null | undefined>(textFieldProps.label);
@@ -20,14 +22,14 @@ assertType<ARIAMixin['ariaLabel'] | undefined>(textFieldProps.ariaLabel);
 assertType<AriaAttributes['aria-label'] | undefined>(textFieldProps['aria-label']);
 
 // Assert that certain HTMLElement properties are NOT present
-assertType<keyof Omit<HTMLElement, keyof typeof textFieldProps>>('append');
-assertType<keyof Omit<HTMLElement, keyof typeof textFieldProps>>('prepend');
+assertOmitted<HTMLElement, TextFieldProps>('append');
+assertOmitted<HTMLElement, TextFieldProps>('prepend');
 
 // Assert that certain LitElement properties are NOT present
-assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('renderRoot');
-assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('requestUpdate');
-assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('addController');
-assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('removeController');
+assertOmitted<LitElement, TextFieldProps>('renderRoot');
+assertOmitted<LitElement, TextFieldProps>('requestUpdate');
+assertOmitted<LitElement, TextFieldProps>('addController');
+assertOmitted<LitElement, TextFieldProps>('removeController');
 
 const gridColumnProps = React.createElement(GridColumn, {}).props;
 // TODO: This should come from the GridColumn API, not from HTMLAttributes

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -10,7 +10,10 @@ const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
 const textFieldProps = React.createElement(TextField, {}).props;
 type TextFieldProps = typeof textFieldProps;
 
-type PartialTextFieldElement = Omit<Partial<TextFieldElement>, 'draggable' | 'style' | 'translate' | 'children' | 'contentEditable'>;
+type PartialTextFieldElement = Omit<
+  Partial<TextFieldElement>,
+  'draggable' | 'style' | 'translate' | 'children' | 'contentEditable'
+>;
 
 assertType<PartialTextFieldElement>(textFieldProps);
 
@@ -39,9 +42,16 @@ assertOmitted<LitElement, TextFieldProps>('addController');
 assertOmitted<LitElement, TextFieldProps>('removeController');
 
 const gridColumnProps = React.createElement(GridColumn, {}).props;
-// TODO: This should come from the GridColumn API, not from HTMLAttributes
+type GridColumnProps = typeof gridColumnProps;
 assertType<GridColumnElement['hidden'] | undefined>(gridColumnProps.hidden);
 
-const dialogProps = React.createElement(Dialog, {}).props;
+assertOmitted<HTMLElement, GridColumnProps>('append');
+assertOmitted<HTMLElement, GridColumnProps>('prepend');
+assertOmitted<HTMLElement, GridColumnProps>('ariaLabel');
 
-assertType<DialogElement['ariaLabel'] | undefined>(dialogProps.ariaLabel);
+const dialogProps = React.createElement(Dialog, {}).props;
+type DialogProps = typeof dialogProps;
+
+assertType<DialogElement['ariaLabel'] | undefined>(dialogProps['aria-label']);
+
+assertType<DialogProps['footer']>(dialogProps.footer);

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,6 +1,7 @@
 import React, { type AriaAttributes, type CSSProperties } from 'react';
 import { TextField } from '../src/TextField.js';
 import type { LitElement } from 'lit';
+import { GridColumn } from '../src/GridColumn.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
@@ -19,13 +20,15 @@ assertType<ARIAMixin['ariaLabel'] | undefined>(textFieldProps.ariaLabel);
 assertType<AriaAttributes['aria-label'] | undefined>(textFieldProps['aria-label']);
 
 // Assert that certain HTMLElement properties are NOT present
-type OmittedProps = Omit<HTMLElement, keyof typeof textFieldProps>;
-assertType<keyof Partial<OmittedProps>>('append');
-assertType<keyof Partial<OmittedProps>>('prepend');
+assertType<keyof Omit<HTMLElement, keyof typeof textFieldProps>>('append');
+assertType<keyof Omit<HTMLElement, keyof typeof textFieldProps>>('prepend');
 
 // Assert that certain LitElement properties are NOT present
-type OmittedLitProps = Omit<LitElement, keyof typeof textFieldProps>;
-assertType<keyof Partial<OmittedLitProps>>('renderRoot');
-assertType<keyof Partial<OmittedLitProps>>('requestUpdate');
-assertType<keyof Partial<OmittedLitProps>>('addController');
-assertType<keyof Partial<OmittedLitProps>>('removeController');
+assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('renderRoot');
+assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('requestUpdate');
+assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('addController');
+assertType<keyof Omit<LitElement, keyof typeof textFieldProps>>('removeController');
+
+const gridColumnProps = React.createElement(GridColumn, {}).props;
+// TODO: This should come from the GridColumn API, not from HTMLAttributes
+assertType<boolean | undefined>(gridColumnProps.hidden);

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,0 +1,24 @@
+import React, { type AriaAttributes, type CSSProperties } from 'react';
+import { TextField } from '../src/TextField.js';
+
+const assertType = <TExpected>(value: TExpected) => value;
+
+const textFieldProps = React.createElement(TextField, {}).props;
+
+// Assert that certain properties are present
+assertType<string | null | undefined>(textFieldProps.label);
+assertType<boolean | undefined>(textFieldProps.hidden);
+assertType<CSSProperties | undefined>(textFieldProps.style);
+assertType<string | undefined>(textFieldProps.className);
+assertType<string | undefined>(textFieldProps.slot);
+assertType<string | undefined>(textFieldProps.title);
+assertType<string | undefined>(textFieldProps.id);
+assertType<React.ReactNode>(textFieldProps.children);
+assertType<ARIAMixin['ariaLabel'] | undefined>(textFieldProps.ariaLabel);
+assertType<AriaAttributes['aria-label'] | undefined>(textFieldProps['aria-label']);
+
+
+// Assert that certain HTMLElement properties are NOT present
+type OmittedProps = Omit<HTMLElement, keyof typeof textFieldProps>
+assertType<keyof Partial<OmittedProps>>('append');
+assertType<keyof Partial<OmittedProps>>('prepend');

--- a/test/typings.ts
+++ b/test/typings.ts
@@ -1,5 +1,6 @@
 import React, { type AriaAttributes, type CSSProperties } from 'react';
 import { TextField } from '../src/TextField.js';
+import type { LitElement } from 'lit';
 
 const assertType = <TExpected>(value: TExpected) => value;
 
@@ -17,8 +18,14 @@ assertType<React.ReactNode>(textFieldProps.children);
 assertType<ARIAMixin['ariaLabel'] | undefined>(textFieldProps.ariaLabel);
 assertType<AriaAttributes['aria-label'] | undefined>(textFieldProps['aria-label']);
 
-
 // Assert that certain HTMLElement properties are NOT present
-type OmittedProps = Omit<HTMLElement, keyof typeof textFieldProps>
+type OmittedProps = Omit<HTMLElement, keyof typeof textFieldProps>;
 assertType<keyof Partial<OmittedProps>>('append');
 assertType<keyof Partial<OmittedProps>>('prepend');
+
+// Assert that certain LitElement properties are NOT present
+type OmittedLitProps = Omit<LitElement, keyof typeof textFieldProps>;
+assertType<keyof Partial<OmittedLitProps>>('renderRoot');
+assertType<keyof Partial<OmittedLitProps>>('requestUpdate');
+assertType<keyof Partial<OmittedLitProps>>('addController');
+assertType<keyof Partial<OmittedLitProps>>('removeController');

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -1,8 +1,8 @@
-import React, { type HTMLAttributes } from 'react';
-import { TextField, TextFieldElement } from '../src/TextField.js';
+import React, { type HTMLAttributes, type RefAttributes } from 'react';
+import { TextField, TextFieldElement } from '../../TextField.js';
 import type { LitElement } from 'lit';
-import { GridColumn, GridColumnElement } from '../src/GridColumn.js';
-import { Dialog, DialogElement } from '../src/Dialog.js';
+import { GridColumn, GridColumnElement } from '../../GridColumn.js';
+import { Dialog, DialogElement } from '../../Dialog.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
@@ -29,6 +29,8 @@ assertType<HTMLAttributes<TextFieldElement>['className']>(textFieldProps.classNa
 assertType<HTMLAttributes<TextFieldElement>['style']>(textFieldProps.style);
 assertType<HTMLAttributes<TextFieldElement>['children']>(textFieldProps.children);
 assertType<HTMLAttributes<TextFieldElement>['aria-label']>(textFieldProps['aria-label']);
+
+assertType<RefAttributes<TextFieldElement>['ref']>(textFieldProps.ref);
 
 // Assert that certain HTMLElement properties are NOT present
 assertOmitted<HTMLElement, TextFieldProps>('append');


### PR DESCRIPTION
## Description

Omit the `HTMLElement` interface in favor of `React.HTMLAttributes` from all Vaadin React components. This will eliminate clutter from the component public API including properties such as `parentElement`, `offsetHeight`, and `appendChild`.

Before:
![Screenshot 2023-12-08 at 12 19 57](https://github.com/vaadin/react-components/assets/1222264/d843292e-d5c8-422b-bd85-381bf07ec8ff)

After:
![Screenshot 2023-12-08 at 12 20 47](https://github.com/vaadin/react-components/assets/1222264/3ccefd88-36bd-4ce6-a00c-ccc4ca3c072e)


Also, `ControllerMixinClass` properties (`addController` and `removeController`) are manually excluded.

Part of https://github.com/vaadin/react-components/issues/161

## Type of change

Refactor