### PR TITLE
fix: allow using slotted elements in Select

### DIFF
--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -30,13 +30,13 @@ function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElem
   const children = Array.isArray(props.children) ? props.children : [props.children];
 
   // Components with slot attribute should stay in light DOM.
-  const slotted = children.filter((child): child is ReactNode => {
+  const slottedChildren = children.filter((child): child is ReactNode => {
     return isValidElement(child) && child.props.slot;
   });
 
   // Component without slot attribute should go to the overlay.
   const overlayChildren = children.filter((child): child is ReactNode => {
-    return isValidElement(child) && !slotted.includes(child);
+    return isValidElement(child) && !slottedChildren.includes(child);
   });
 
   const renderFn = children.find((child) => typeof child === 'function');
@@ -56,7 +56,7 @@ function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElem
 
   return (
     <_Select {...props} ref={finalRef} renderer={renderer}>
-      {slotted}
+      {slottedChildren}
       {portals}
     </_Select>
   );

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -29,29 +29,23 @@ function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElem
   const children = Children.toArray(props.children as ReactNode[]);
 
   // Components with slot attribute should stay in light DOM.
-  const slotted = children.filter((child: any) => {
-    return 'props' in child && child.props.slot;
+  const slotted = children.filter((child) => {
+    return typeof child === 'object' && 'props' in child && child.props.slot;
   });
 
   // Component without slot attribute should go to the overlay.
-  let overlayChildren: ReactNode[] | undefined;
-
-  children.forEach((child) => {
-    if (!slotted.includes(child)) {
-      if (!overlayChildren) {
-        overlayChildren = [];
-      }
-      overlayChildren.push(child);
-    }
-  });
+  const overlayChildren = children.filter((child) => !slotted.includes(child));
 
   // React.Children.toArray() doesn't allow functions, so we convert manually.
   const renderFn = (Array.isArray(props.children) ? props.children : [props.children]).find(
-    (child: any) => typeof child === 'function',
+    (child) => typeof child === 'function',
   );
 
   const innerRef = useRef<SelectElement>(null);
-  const [portals, renderer] = useSimpleOrChildrenRenderer(props.renderer, renderFn || overlayChildren);
+  const [portals, renderer] = useSimpleOrChildrenRenderer(
+    props.renderer,
+    renderFn || (overlayChildren.length ? overlayChildren : undefined),
+  );
   const finalRef = useMergedRefs(innerRef, ref);
 
   useEffect(() => {

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -1,4 +1,5 @@
 import {
+  Children,
   type ComponentType,
   type ForwardedRef,
   forwardRef,
@@ -16,15 +17,41 @@ export * from './generated/Select.js';
 
 export type SelectReactRendererProps = ReactSimpleRendererProps<SelectElement>;
 
+type SelectRenderer = ComponentType<SelectReactRendererProps>;
+
 export type SelectProps = Partial<Omit<_SelectProps, 'children' | 'renderer'>> &
   Readonly<{
-    children?: ReactNode | ComponentType<SelectReactRendererProps>;
-    renderer?: ComponentType<SelectReactRendererProps> | null;
+    children?: ReactNode | SelectRenderer | Array<ReactNode | SelectRenderer>;
+    renderer?: SelectRenderer | null;
   }>;
 
 function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElement | null {
+  const children = Children.toArray(props.children as ReactNode[]);
+
+  // Components with slot attribute should stay in light DOM.
+  const slotted = children.filter((child: any) => {
+    return 'props' in child && child.props.slot;
+  });
+
+  // Component without slot attribute should go to the overlay.
+  let overlayChildren: ReactNode[] | undefined;
+
+  children.forEach((child) => {
+    if (!slotted.includes(child)) {
+      if (!overlayChildren) {
+        overlayChildren = [];
+      }
+      overlayChildren.push(child);
+    }
+  });
+
+  // React.Children.toArray() doesn't allow functions, so we convert manually.
+  const renderFn = (Array.isArray(props.children) ? props.children : [props.children]).find(
+    (child: any) => typeof child === 'function',
+  );
+
   const innerRef = useRef<SelectElement>(null);
-  const [portals, renderer] = useSimpleOrChildrenRenderer(props.renderer, props.children);
+  const [portals, renderer] = useSimpleOrChildrenRenderer(props.renderer, renderFn || overlayChildren);
   const finalRef = useMergedRefs(innerRef, ref);
 
   useEffect(() => {
@@ -35,6 +62,7 @@ function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElem
 
   return (
     <_Select {...props} ref={finalRef} renderer={renderer}>
+      {slotted}
       {portals}
     </_Select>
   );

--- a/test/Select.spec.tsx
+++ b/test/Select.spec.tsx
@@ -95,10 +95,47 @@ describe('Select', () => {
 
       await expect(findByQuerySelector('vaadin-select-value-button')).to.eventually.have.text('Bar');
     });
+  });
 
-    it('should correctly render the element with prefix slot', async () => {
+  describe('slot', () => {
+    it('should render the element with slot if renderer prop is set', async () => {
       render(
         <Select renderer={Renderer}>
+          <div slot="prefix">Value:</div>
+        </Select>,
+      );
+
+      await expect(findByQuerySelector('div[slot="prefix"]')).to.eventually.have.text('Value:');
+    });
+
+    it('should render the element with slot if items prop is set', async () => {
+      render(
+        <Select items={items}>
+          <div slot="prefix">Value:</div>
+        </Select>,
+      );
+
+      await expect(findByQuerySelector('div[slot="prefix"]')).to.eventually.have.text('Value:');
+    });
+
+    it('should render the element with slot if children render function is set', async () => {
+      render(
+        <Select>
+          {Renderer}
+          <div slot="prefix">Value:</div>
+        </Select>,
+      );
+
+      await expect(findByQuerySelector('div[slot="prefix"]')).to.eventually.have.text('Value:');
+    });
+
+    it('should render the element with slot if children component is set', async () => {
+      render(
+        <Select>
+          <ListBox>
+            <Item value="foo">Foo</Item>
+            <Item value="bar">Bar</Item>
+          </ListBox>
           <div slot="prefix">Value:</div>
         </Select>,
       );

--- a/test/Select.spec.tsx
+++ b/test/Select.spec.tsx
@@ -95,5 +95,15 @@ describe('Select', () => {
 
       await expect(findByQuerySelector('vaadin-select-value-button')).to.eventually.have.text('Bar');
     });
+
+    it('should correctly render the element with prefix slot', async () => {
+      render(
+        <Select renderer={Renderer}>
+          <div slot="prefix">Value:</div>
+        </Select>,
+      );
+
+      await expect(findByQuerySelector('div[slot="prefix"]')).to.eventually.have.text('Value:');
+    });
   });
 });

--- a/test/kitchen-sink/Row8.tsx
+++ b/test/kitchen-sink/Row8.tsx
@@ -5,6 +5,7 @@ import { RadioButton } from '../../src/RadioButton.js';
 import { RadioGroup } from '../../src/RadioGroup.js';
 import { RichTextEditor } from '../../src/RichTextEditor.js';
 import { Select } from '../../src/Select.js';
+import { Tooltip } from '../../src/Tooltip.js';
 
 function SelectListBox() {
   return (
@@ -27,7 +28,11 @@ export default function Row8() {
         </RadioButton>
       </RadioGroup>
       <RichTextEditor></RichTextEditor>
-      <Select label="Select" value="2" renderer={SelectListBox} />
+      <Select label="Select" value="2">
+        {SelectListBox}
+        <span slot="prefix">+</span>
+        <Tooltip slot="tooltip" text="Select tooltip"></Tooltip>
+      </Select>
     </BoardRow>
   );
 }


### PR DESCRIPTION
## Description

Fixes #131

Previously, `Select` passed `props.children` to `useSimpleOrChildrenRenderer` as is. This PR changes it so that we get elements with `slot` to be rendered in light DOM, and then evaluate remaining `children` to pass to the hook.

## Type of change

- Bugfix