### PR TITLE
refactor!: use new Lit React package instead of Lit Labs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@lit/react": "^1.0.0",
         "@vaadin/a11y-base": "24.3.0",
         "@vaadin/accordion": "24.3.0",
         "@vaadin/app-layout": "24.3.0",
@@ -109,7 +110,6 @@
         "vite": "^4.3.9"
       },
       "peerDependencies": {
-        "@lit-labs/react": "^1.1.0",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",
         "react": "^18.2.0",
@@ -1649,16 +1649,18 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
-    "node_modules/@lit-labs/react": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
-      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==",
-      "peer": true
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
       "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.2.tgz",
+      "integrity": "sha512-UJ5TQ46DPcJDIzyjbwbj6Iye0XcpCxL2yb03zcWq1BpWchpXS3Z0BPVhg7zDfZLF6JemPml8u/gt/+KwJ/23sg==",
+      "peerDependencies": {
+        "@types/react": "17 || 18"
+      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.0.0",
@@ -1913,14 +1915,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/react": {
       "version": "18.2.37",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.37.tgz",
       "integrity": "sha512-RGAYMi2bhRgEXT3f4B92WTohopH6bIXw05FuGlmJEnv/omEn190+QYEIYxIAuIBdKgboYYdVved2p1AxZVQnaw==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1939,8 +1939,7 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.4",
@@ -3647,8 +3646,7 @@
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
-      "devOptional": true
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/custom-event": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "url": "github.com/vaadin/react-components"
   },
   "dependencies": {
+    "@lit/react": "^1.0.0",
     "@vaadin/a11y-base": "24.3.0",
     "@vaadin/accordion": "24.3.0",
     "@vaadin/app-layout": "24.3.0",
@@ -109,7 +110,6 @@
     "esbuild": "$esbuild"
   },
   "peerDependencies": {
-    "@lit-labs/react": "^1.1.0",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "react": "^18.2.0",

--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -35,7 +35,7 @@ const CREATE_COMPONENT_PATH = '$CREATE_COMPONENT_PATH$';
 const EVENT_MAP = '$EVENT_MAP$';
 const EVENT_MAP_REF_IN_EVENTS = '$EVENT_MAP_REF_IN_EVENTS$';
 const EVENTS_DECLARATION = '$EVENTS_DECLARATION$';
-const LIT_REACT_PATH = '@lit-labs/react';
+const LIT_REACT_PATH = '@lit/react';
 const MODULE_PATH = '$MODULE_PATH$';
 
 type ElementData = Readonly<{

--- a/src/utils/createComponent.ts
+++ b/src/utils/createComponent.ts
@@ -48,7 +48,8 @@ type EventListeners<R extends EventNames> = {
 
 // Props derived from custom element class. Currently has limitations of making
 // all properties optional and also surfaces life cycle methods in autocomplete.
-type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>>;
+// TODO: LoginOverlay has "autofocus" property, so we add it back manually.
+type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>> & { autofocus?: boolean };
 
 // Acceptable props to the React component.
 type ComponentProps<I, E extends EventNames = {}> = Omit<
@@ -77,12 +78,9 @@ type AllWebComponentProps<I extends HTMLElement, E extends EventNames = {}> = I 
   ? ThemedWebComponentProps<I, E>
   : ComponentProps<I, E>;
 
-// TODO: LoginOverlay has "autofocus" property so we can't omit it
-type OmittedWebComponentProps = Omit<HTMLElement, keyof React.HTMLAttributes<any> | 'autofocus'> & ControllerMixinClass;
-
 export type WebComponentProps<I extends HTMLElement, E extends EventNames = {}> = Omit<
   AllWebComponentProps<I, E>,
-  keyof OmittedWebComponentProps
+  keyof ControllerMixinClass
 >;
 
 // We need a separate declaration here; otherwise, the TypeScript fails into the

--- a/src/utils/createComponent.ts
+++ b/src/utils/createComponent.ts
@@ -1,4 +1,4 @@
-import { createComponent as _createComponent, type EventName } from '@lit/react';
+import { createComponent as _createComponent, type EventName, type ReactWebComponent } from '@lit/react';
 import type { ThemePropertyMixinClass } from '@vaadin/vaadin-themable-mixin/vaadin-theme-property-mixin.js';
 import type React from 'react';
 import type { RefAttributes } from 'react';
@@ -41,25 +41,10 @@ type Options<I extends HTMLElement, E extends EventNames = {}> = Readonly<{
   tagName: string;
 }>;
 
-// A map of expected event listener types based on EventNames.
-type EventListeners<R extends EventNames> = {
-  [K in keyof R]?: R[K] extends EventName ? (e: R[K]['__eventType']) => void : (e: Event) => void;
-};
-
-// Props derived from custom element class. Currently has limitations of making
-// all properties optional and also surfaces life cycle methods in autocomplete.
 // TODO: LoginOverlay has "autofocus" property, so we add it back manually.
-type ElementProps<I> = Partial<Omit<I, keyof HTMLElement>> & { autofocus?: boolean };
-
-// Acceptable props to the React component.
-type ComponentProps<I, E extends EventNames = {}> = Omit<
-  React.HTMLAttributes<I>,
-  // Prefer type of provided event handler props or those on element over
-  // built-in HTMLAttributes
-  keyof E | keyof ElementProps<I>
-> &
-  EventListeners<E> &
-  ElementProps<I>;
+type ComponentProps<I extends HTMLElement, E extends EventNames = {}> = React.ComponentProps<
+  ReactWebComponent<I, E>
+> & { autofocus?: boolean };
 
 export type ThemedWebComponentProps<
   I extends ThemePropertyMixinClass & HTMLElement,


### PR DESCRIPTION
## Description

Changed to use `@lit/react` instead of `@lit-labs/react` and updated types.

In order to migrate to the new package, I had to update `createComponent` return type and copy a [few types from here](https://github.com/lit/lit/blame/25fbfba9c0f1b97d720a981831c59c08472ba6ee/packages/react/src/create-component.ts#L46-L69).
This is because of the fact that `WebComponentProps` is now replaced with `ComponentProps` type (not exported).

Some relevant changes included to the new package:

- https://github.com/lit/lit/pull/4027
- https://github.com/lit/lit/pull/4381

UPD: partially reverts #167 as `@lit/react` has [its own logic](https://github.com/lit/lit/blame/25fbfba9c0f1b97d720a981831c59c08472ba6ee/packages/react/src/create-component.ts#L59) to exclude HTMLElement API that I copied over.

## Type of change

- Refactor (potentially breaking change)