### PR TITLE
refactor: omit HTMLAttributes from non-visual component props

### DIFF
--- a/src/ChartSeries.ts
+++ b/src/ChartSeries.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  ChartSeriesElement,
+  ChartSeries as _ChartSeries,
+  type ChartSeriesProps as _ChartSeriesProps,
+} from './generated/ChartSeries.js';
+
 export * from './generated/ChartSeries.js';
+
+type OmittedChartSeriesHTMLAttributes = Omit<
+  HTMLAttributes<ChartSeriesElement>,
+  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'title'
+>;
+
+export type ChartSeriesProps = Partial<Omit<_ChartSeriesProps, keyof OmittedChartSeriesHTMLAttributes>>;
+
+export const ChartSeries = _ChartSeries as (
+  props: ChartSeriesProps & RefAttributes<ChartSeriesElement>,
+) => ReactElement | null;

--- a/src/ChartSeries.ts
+++ b/src/ChartSeries.ts
@@ -9,7 +9,7 @@ export * from './generated/ChartSeries.js';
 
 type OmittedChartSeriesHTMLAttributes = Omit<
   HTMLAttributes<ChartSeriesElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'title'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'title'
 >;
 
 export type ChartSeriesProps = Partial<Omit<_ChartSeriesProps, keyof OmittedChartSeriesHTMLAttributes>>;

--- a/src/ConfirmDialog.ts
+++ b/src/ConfirmDialog.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  ConfirmDialogElement,
+  ConfirmDialog as _ConfirmDialog,
+  type ConfirmDialogProps as _ConfirmDialogProps,
+} from './generated/ConfirmDialog.js';
+
 export * from './generated/ConfirmDialog.js';
+
+type OmittedConfirmDialogHTMLAttributes = Omit<
+  HTMLAttributes<ConfirmDialogElement>,
+  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'aria-label'
+>;
+
+export type ConfirmDialogProps = Partial<Omit<_ConfirmDialogProps, keyof OmittedConfirmDialogHTMLAttributes>>;
+
+export const ConfirmDialog = _ConfirmDialog as (
+  props: ConfirmDialogProps & RefAttributes<ConfirmDialogElement>,
+) => ReactElement | null;

--- a/src/ConfirmDialog.ts
+++ b/src/ConfirmDialog.ts
@@ -9,7 +9,7 @@ export * from './generated/ConfirmDialog.js';
 
 type OmittedConfirmDialogHTMLAttributes = Omit<
   HTMLAttributes<ConfirmDialogElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'aria-label'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'aria-label'
 >;
 
 export type ConfirmDialogProps = Partial<Omit<_ConfirmDialogProps, keyof OmittedConfirmDialogHTMLAttributes>>;

--- a/src/CookieConsent.ts
+++ b/src/CookieConsent.ts
@@ -9,7 +9,7 @@ export * from './generated/CookieConsent.js';
 
 type OmittedCookieConsentHTMLAttributes = Omit<
   HTMLAttributes<CookieConsentElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot'
 >;
 
 export type CookieConsentProps = Partial<Omit<_CookieConsentProps, keyof OmittedCookieConsentHTMLAttributes>>;

--- a/src/CookieConsent.ts
+++ b/src/CookieConsent.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  CookieConsentElement,
+  CookieConsent as _CookieConsent,
+  type CookieConsentProps as _CookieConsentProps,
+} from './generated/CookieConsent.js';
+
 export * from './generated/CookieConsent.js';
+
+type OmittedCookieConsentHTMLAttributes = Omit<
+  HTMLAttributes<CookieConsentElement>,
+  'id' | 'dangerouslySetInnerHTML' | 'slot'
+>;
+
+export type CookieConsentProps = Partial<Omit<_CookieConsentProps, keyof OmittedCookieConsentHTMLAttributes>>;
+
+export const CookieConsent = _CookieConsent as (
+  props: CookieConsentProps & RefAttributes<CookieConsentElement>,
+) => ReactElement | null;

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -16,7 +16,7 @@ export type DialogReactRendererProps = ReactSimpleRendererProps<DialogElement>;
 
 type OmittedDialogHTMLAttributes = Omit<
   HTMLAttributes<DialogElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'aria-label' | 'draggable'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'aria-label' | 'draggable'
 >;
 
 export type DialogProps = Partial<

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,4 +1,11 @@
-import { type ComponentType, type ForwardedRef, forwardRef, type ReactElement, type ReactNode } from 'react';
+import {
+  type ComponentType,
+  type ForwardedRef,
+  type HTMLAttributes,
+  forwardRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { Dialog as _Dialog, type DialogElement, type DialogProps as _DialogProps } from './generated/Dialog.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
 import type { ReactSimpleRendererProps } from './renderers/useSimpleRenderer.js';
@@ -7,7 +14,14 @@ export * from './generated/Dialog.js';
 
 export type DialogReactRendererProps = ReactSimpleRendererProps<DialogElement>;
 
-export type DialogProps = Partial<Omit<_DialogProps, 'children' | 'footerRenderer' | 'headerRenderer' | 'renderer'>> &
+type OmittedDialogHTMLAttributes = Omit<
+  HTMLAttributes<DialogElement>,
+  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'aria-label' | 'draggable'
+>;
+
+export type DialogProps = Partial<
+  Omit<_DialogProps, 'children' | 'footerRenderer' | 'headerRenderer' | 'renderer' | keyof OmittedDialogHTMLAttributes>
+> &
   Readonly<{
     children?: ReactNode | ComponentType<DialogReactRendererProps>;
     footer?: ReactNode;

--- a/src/LoginOverlay.ts
+++ b/src/LoginOverlay.ts
@@ -9,7 +9,7 @@ export * from './generated/LoginOverlay.js';
 
 type OmittedLoginOverlayHTMLAttributes = Omit<
   HTMLAttributes<LoginOverlayElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'children'
+  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'title'
 >;
 
 export type LoginOverlayProps = Partial<Omit<_LoginOverlayProps, keyof OmittedLoginOverlayHTMLAttributes>>;

--- a/src/LoginOverlay.ts
+++ b/src/LoginOverlay.ts
@@ -9,7 +9,7 @@ export * from './generated/LoginOverlay.js';
 
 type OmittedLoginOverlayHTMLAttributes = Omit<
   HTMLAttributes<LoginOverlayElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'title'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'title'
 >;
 
 export type LoginOverlayProps = Partial<Omit<_LoginOverlayProps, keyof OmittedLoginOverlayHTMLAttributes>>;

--- a/src/LoginOverlay.ts
+++ b/src/LoginOverlay.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  LoginOverlayElement,
+  LoginOverlay as _LoginOverlay,
+  type LoginOverlayProps as _LoginOverlayProps,
+} from './generated/LoginOverlay.js';
+
 export * from './generated/LoginOverlay.js';
+
+type OmittedLoginOverlayHTMLAttributes = Omit<
+  HTMLAttributes<LoginOverlayElement>,
+  'id' | 'dangerouslySetInnerHTML' | 'slot' | 'children'
+>;
+
+export type LoginOverlayProps = Partial<Omit<_LoginOverlayProps, keyof OmittedLoginOverlayHTMLAttributes>>;
+
+export const LoginOverlay = _LoginOverlay as (
+  props: LoginOverlayProps & RefAttributes<LoginOverlayElement>,
+) => ReactElement | null;

--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -23,7 +23,7 @@ export type NotificationReactRendererProps = ReactSimpleRendererProps<Notificati
 
 type OmittedNotificationHTMLAttributes = Omit<
   HTMLAttributes<NotificationElement>,
-  'id' | 'dangerouslySetInnerHTML' | 'slot'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot'
 >;
 
 export type NotificationProps = Partial<

--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -3,6 +3,7 @@ import {
   type ForwardedRef,
   forwardRef,
   type ForwardRefExoticComponent,
+  type HTMLAttributes,
   type ReactElement,
   type ReactNode,
   type RefAttributes,
@@ -20,7 +21,14 @@ export * from './generated/Notification.js';
 
 export type NotificationReactRendererProps = ReactSimpleRendererProps<NotificationElement>;
 
-export type NotificationProps = Partial<Omit<_NotificationProps, 'children' | 'renderer'>> &
+type OmittedNotificationHTMLAttributes = Omit<
+  HTMLAttributes<NotificationElement>,
+  'id' | 'dangerouslySetInnerHTML' | 'slot'
+>;
+
+export type NotificationProps = Partial<
+  Omit<_NotificationProps, 'children' | 'renderer' | keyof OmittedNotificationHTMLAttributes>
+> &
   Readonly<{
     children?: ReactNode | ComponentType<NotificationReactRendererProps>;
     renderer?: ComponentType<NotificationReactRendererProps>;

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -9,6 +9,7 @@ import { GridSelectionColumn } from '../../GridSelectionColumn.js';
 import { GridProEditColumn } from '../../GridProEditColumn.js';
 import { GridColumnGroup, GridColumnGroupElement } from '../../GridColumnGroup.js';
 import { ConfirmDialog, ConfirmDialogElement } from '../../ConfirmDialog.js';
+import { CookieConsent, CookieConsentElement } from '../../CookieConsent.js';
 import { Dialog, DialogElement } from '../../Dialog.js';
 import { DatePicker, DatePickerElement } from '../../DatePicker.js';
 import { LoginOverlay, LoginOverlayElement } from '../../LoginOverlay.js';
@@ -141,6 +142,14 @@ assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('className
 assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('style');
 assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('contentEditable');
 assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('onClick');
+
+const cookieConsentProps = React.createElement(CookieConsent, {}).props;
+type CookieConsentProps = typeof cookieConsentProps;
+
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('className');
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('style');
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('contentEditable');
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('onClick');
 
 const datePickerProps = React.createElement(DatePicker, {}).props;
 

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -121,7 +121,6 @@ assertType<DialogProps['footer']>(dialogProps.footer);
 assertType<DialogProps['draggable']>(dialogProps.draggable);
 assertType<DialogProps['resizable']>(dialogProps.resizable);
 
-assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('className');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('style');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('contentEditable');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('onClick');
@@ -131,7 +130,6 @@ type ConfirmDialogProps = typeof confirmDialogProps;
 
 assertType<ConfirmDialogElement['ariaLabel'] | undefined>(confirmDialogProps['aria-label']);
 
-assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('className');
 assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('style');
 assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('contentEditable');
 assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('onClick');
@@ -139,7 +137,6 @@ assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('onClick
 const notificationProps = React.createElement(Notification, {}).props;
 type NotificationProps = typeof notificationProps;
 
-assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('className');
 assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('style');
 assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('contentEditable');
 assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('onClick');
@@ -147,7 +144,6 @@ assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('onClick')
 const cookieConsentProps = React.createElement(CookieConsent, {}).props;
 type CookieConsentProps = typeof cookieConsentProps;
 
-assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('className');
 assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('style');
 assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('contentEditable');
 assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('onClick');
@@ -155,7 +151,6 @@ assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('onClick
 const chartSeriesProps = React.createElement(ChartSeries, {}).props;
 type ChartSeriesProps = typeof chartSeriesProps;
 
-assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('className');
 assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('style');
 assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('contentEditable');
 assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('onClick');
@@ -196,7 +191,6 @@ assertType<LoginOverlayElement['autofocus'] | undefined>(loginOverlayProps.autof
 type LoginOverlayProps = typeof loginOverlayProps;
 
 assertType<string | undefined>(loginOverlayProps.title);
-assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('className');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('style');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('contentEditable');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('onClick');

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -8,6 +8,7 @@ import { GridFilterColumn } from '../../GridFilterColumn.js';
 import { GridSelectionColumn } from '../../GridSelectionColumn.js';
 import { GridProEditColumn } from '../../GridProEditColumn.js';
 import { GridColumnGroup, GridColumnGroupElement } from '../../GridColumnGroup.js';
+import { ChartSeries, ChartSeriesElement } from '../../ChartSeries.js';
 import { ConfirmDialog, ConfirmDialogElement } from '../../ConfirmDialog.js';
 import { CookieConsent, CookieConsentElement } from '../../CookieConsent.js';
 import { Dialog, DialogElement } from '../../Dialog.js';
@@ -150,6 +151,14 @@ assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('classNa
 assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('style');
 assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('contentEditable');
 assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('onClick');
+
+const chartSeriesProps = React.createElement(ChartSeries, {}).props;
+type ChartSeriesProps = typeof chartSeriesProps;
+
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('className');
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('style');
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('contentEditable');
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('onClick');
 
 const datePickerProps = React.createElement(DatePicker, {}).props;
 

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -175,3 +175,9 @@ assertType<typeof timePickerProps.onChange>((_event: TimePickerChangeEvent) => {
 const loginOverlayProps = React.createElement(LoginOverlay, {}).props;
 
 assertType<LoginOverlayElement['autofocus'] | undefined>(loginOverlayProps.autofocus);
+type LoginOverlayProps = typeof loginOverlayProps;
+
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('className');
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('style');
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('contentEditable');
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('onClick');

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -11,6 +11,7 @@ import { GridColumnGroup, GridColumnGroupElement } from '../../GridColumnGroup.j
 import { Dialog, DialogElement } from '../../Dialog.js';
 import { DatePicker, DatePickerElement } from '../../DatePicker.js';
 import { LoginOverlay, LoginOverlayElement } from '../../LoginOverlay.js';
+import { Notification, NotificationElement } from '../../Notification.js';
 import { TimePicker, type TimePickerChangeEvent } from '../../TimePicker.js';
 import { TextArea, TextAreaElement, type TextAreaChangeEvent } from '../../TextArea.js';
 import { MessageInput, MessageInputElement, type MessageInputSubmitEvent } from '../../MessageInput.js';
@@ -121,6 +122,14 @@ assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('className');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('style');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('contentEditable');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('onClick');
+
+const notificationProps = React.createElement(Notification, {}).props;
+type NotificationProps = typeof notificationProps;
+
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('className');
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('style');
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('contentEditable');
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('onClick');
 
 const datePickerProps = React.createElement(DatePicker, {}).props;
 

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -8,6 +8,7 @@ import { GridFilterColumn } from '../../GridFilterColumn.js';
 import { GridSelectionColumn } from '../../GridSelectionColumn.js';
 import { GridProEditColumn } from '../../GridProEditColumn.js';
 import { GridColumnGroup, GridColumnGroupElement } from '../../GridColumnGroup.js';
+import { ConfirmDialog, ConfirmDialogElement } from '../../ConfirmDialog.js';
 import { Dialog, DialogElement } from '../../Dialog.js';
 import { DatePicker, DatePickerElement } from '../../DatePicker.js';
 import { LoginOverlay, LoginOverlayElement } from '../../LoginOverlay.js';
@@ -122,6 +123,16 @@ assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('className');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('style');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('contentEditable');
 assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('onClick');
+
+const confirmDialogProps = React.createElement(ConfirmDialog, {}).props;
+type ConfirmDialogProps = typeof confirmDialogProps;
+
+assertType<ConfirmDialogElement['ariaLabel'] | undefined>(confirmDialogProps['aria-label']);
+
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('className');
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('style');
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('contentEditable');
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('onClick');
 
 const notificationProps = React.createElement(Notification, {}).props;
 type NotificationProps = typeof notificationProps;

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -114,6 +114,13 @@ type DialogProps = typeof dialogProps;
 assertType<DialogElement['ariaLabel'] | undefined>(dialogProps['aria-label']);
 
 assertType<DialogProps['footer']>(dialogProps.footer);
+assertType<DialogProps['draggable']>(dialogProps.draggable);
+assertType<DialogProps['resizable']>(dialogProps.resizable);
+
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('className');
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('style');
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('contentEditable');
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('onClick');
 
 const datePickerProps = React.createElement(DatePicker, {}).props;
 

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -195,6 +195,7 @@ const loginOverlayProps = React.createElement(LoginOverlay, {}).props;
 assertType<LoginOverlayElement['autofocus'] | undefined>(loginOverlayProps.autofocus);
 type LoginOverlayProps = typeof loginOverlayProps;
 
+assertType<string | undefined>(loginOverlayProps.title);
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('className');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('style');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('contentEditable');


### PR DESCRIPTION
## Description

Fixes #192

- [x] Dialog
- [x] ConfirmDialog
- [x] CookieConsent
- [x] LoginOverlay
- [x] Notification
- [x] ChartSeries

## Type of change

- Refactor