### PR TITLE
refactor: omit HTMLAttributes from non-visual component props (#200) (CP: 2.3)

### DIFF
--- a/src/ChartSeries.ts
+++ b/src/ChartSeries.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  ChartSeriesElement,
+  ChartSeries as _ChartSeries,
+  type ChartSeriesProps as _ChartSeriesProps,
+} from './generated/ChartSeries.js';
+
 export * from './generated/ChartSeries.js';
+
+type OmittedChartSeriesHTMLAttributes = Omit<
+  HTMLAttributes<ChartSeriesElement>,
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'title'
+>;
+
+export type ChartSeriesProps = Partial<Omit<_ChartSeriesProps, keyof OmittedChartSeriesHTMLAttributes>>;
+
+export const ChartSeries = _ChartSeries as (
+  props: ChartSeriesProps & RefAttributes<ChartSeriesElement>,
+) => ReactElement | null;

--- a/src/ConfirmDialog.ts
+++ b/src/ConfirmDialog.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  ConfirmDialogElement,
+  ConfirmDialog as _ConfirmDialog,
+  type ConfirmDialogProps as _ConfirmDialogProps,
+} from './generated/ConfirmDialog.js';
+
 export * from './generated/ConfirmDialog.js';
+
+type OmittedConfirmDialogHTMLAttributes = Omit<
+  HTMLAttributes<ConfirmDialogElement>,
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'aria-label'
+>;
+
+export type ConfirmDialogProps = Partial<Omit<_ConfirmDialogProps, keyof OmittedConfirmDialogHTMLAttributes>>;
+
+export const ConfirmDialog = _ConfirmDialog as (
+  props: ConfirmDialogProps & RefAttributes<ConfirmDialogElement>,
+) => ReactElement | null;

--- a/src/CookieConsent.ts
+++ b/src/CookieConsent.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  CookieConsentElement,
+  CookieConsent as _CookieConsent,
+  type CookieConsentProps as _CookieConsentProps,
+} from './generated/CookieConsent.js';
+
 export * from './generated/CookieConsent.js';
+
+type OmittedCookieConsentHTMLAttributes = Omit<
+  HTMLAttributes<CookieConsentElement>,
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot'
+>;
+
+export type CookieConsentProps = Partial<Omit<_CookieConsentProps, keyof OmittedCookieConsentHTMLAttributes>>;
+
+export const CookieConsent = _CookieConsent as (
+  props: CookieConsentProps & RefAttributes<CookieConsentElement>,
+) => ReactElement | null;

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,4 +1,11 @@
-import { type ComponentType, type ForwardedRef, forwardRef, type ReactElement, type ReactNode } from 'react';
+import {
+  type ComponentType,
+  type ForwardedRef,
+  type HTMLAttributes,
+  forwardRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { Dialog as _Dialog, type DialogElement, type DialogProps as _DialogProps } from './generated/Dialog.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
 import type { ReactSimpleRendererProps } from './renderers/useSimpleRenderer.js';
@@ -7,7 +14,14 @@ export * from './generated/Dialog.js';
 
 export type DialogReactRendererProps = ReactSimpleRendererProps<DialogElement>;
 
-export type DialogProps = Partial<Omit<_DialogProps, 'children' | 'footerRenderer' | 'headerRenderer' | 'renderer'>> &
+type OmittedDialogHTMLAttributes = Omit<
+  HTMLAttributes<DialogElement>,
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'aria-label' | 'draggable'
+>;
+
+export type DialogProps = Partial<
+  Omit<_DialogProps, 'children' | 'footerRenderer' | 'headerRenderer' | 'renderer' | keyof OmittedDialogHTMLAttributes>
+> &
   Readonly<{
     children?: ReactNode | ComponentType<DialogReactRendererProps>;
     footer?: ReactNode;

--- a/src/LoginOverlay.ts
+++ b/src/LoginOverlay.ts
@@ -1,1 +1,19 @@
+import type { HTMLAttributes, ReactElement, RefAttributes } from 'react';
+import {
+  LoginOverlayElement,
+  LoginOverlay as _LoginOverlay,
+  type LoginOverlayProps as _LoginOverlayProps,
+} from './generated/LoginOverlay.js';
+
 export * from './generated/LoginOverlay.js';
+
+type OmittedLoginOverlayHTMLAttributes = Omit<
+  HTMLAttributes<LoginOverlayElement>,
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'title'
+>;
+
+export type LoginOverlayProps = Partial<Omit<_LoginOverlayProps, keyof OmittedLoginOverlayHTMLAttributes>>;
+
+export const LoginOverlay = _LoginOverlay as (
+  props: LoginOverlayProps & RefAttributes<LoginOverlayElement>,
+) => ReactElement | null;

--- a/src/Notification.tsx
+++ b/src/Notification.tsx
@@ -3,6 +3,7 @@ import {
   type ForwardedRef,
   forwardRef,
   type ForwardRefExoticComponent,
+  type HTMLAttributes,
   type ReactElement,
   type ReactNode,
   type RefAttributes,
@@ -20,7 +21,14 @@ export * from './generated/Notification.js';
 
 export type NotificationReactRendererProps = ReactSimpleRendererProps<NotificationElement>;
 
-export type NotificationProps = Partial<Omit<_NotificationProps, 'children' | 'renderer'>> &
+type OmittedNotificationHTMLAttributes = Omit<
+  HTMLAttributes<NotificationElement>,
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot'
+>;
+
+export type NotificationProps = Partial<
+  Omit<_NotificationProps, 'children' | 'renderer' | keyof OmittedNotificationHTMLAttributes>
+> &
   Readonly<{
     children?: ReactNode | ComponentType<NotificationReactRendererProps>;
     renderer?: ComponentType<NotificationReactRendererProps>;

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -2,9 +2,13 @@ import React, { type HTMLAttributes, type RefAttributes } from 'react';
 import { TextField, TextFieldElement } from '../../TextField.js';
 import type { LitElement } from 'lit';
 import { GridColumn, GridColumnElement } from '../../GridColumn.js';
+import { ChartSeries, ChartSeriesElement } from '../../ChartSeries.js';
+import { ConfirmDialog, ConfirmDialogElement } from '../../ConfirmDialog.js';
+import { CookieConsent, CookieConsentElement } from '../../CookieConsent.js';
 import { Dialog, DialogElement } from '../../Dialog.js';
 import { DatePicker, DatePickerElement } from '../../DatePicker.js';
 import { LoginOverlay, LoginOverlayElement } from '../../LoginOverlay.js';
+import { Notification, NotificationElement } from '../../Notification.js';
 import { TimePicker, type TimePickerChangeEvent } from '../../TimePicker.js';
 import { TextArea, TextAreaElement, type TextAreaChangeEvent } from '../../TextArea.js';
 import { MessageInput, MessageInputElement, type MessageInputSubmitEvent } from '../../MessageInput.js';
@@ -63,6 +67,42 @@ type DialogProps = typeof dialogProps;
 assertType<DialogElement['ariaLabel'] | undefined>(dialogProps['aria-label']);
 
 assertType<DialogProps['footer']>(dialogProps.footer);
+assertType<DialogProps['draggable']>(dialogProps.draggable);
+assertType<DialogProps['resizable']>(dialogProps.resizable);
+
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('style');
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('contentEditable');
+assertOmitted<HTMLAttributes<DialogElement>, DialogProps>('onClick');
+
+const confirmDialogProps = React.createElement(ConfirmDialog, {}).props;
+type ConfirmDialogProps = typeof confirmDialogProps;
+
+assertType<ConfirmDialogElement['ariaLabel'] | undefined>(confirmDialogProps['aria-label']);
+
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('style');
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('contentEditable');
+assertOmitted<HTMLAttributes<ConfirmDialogElement>, ConfirmDialogProps>('onClick');
+
+const notificationProps = React.createElement(Notification, {}).props;
+type NotificationProps = typeof notificationProps;
+
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('style');
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('contentEditable');
+assertOmitted<HTMLAttributes<NotificationElement>, NotificationProps>('onClick');
+
+const cookieConsentProps = React.createElement(CookieConsent, {}).props;
+type CookieConsentProps = typeof cookieConsentProps;
+
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('style');
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('contentEditable');
+assertOmitted<HTMLAttributes<CookieConsentElement>, CookieConsentProps>('onClick');
+
+const chartSeriesProps = React.createElement(ChartSeries, {}).props;
+type ChartSeriesProps = typeof chartSeriesProps;
+
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('style');
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('contentEditable');
+assertOmitted<HTMLAttributes<ChartSeriesElement>, ChartSeriesProps>('onClick');
 
 const datePickerProps = React.createElement(DatePicker, {}).props;
 
@@ -97,3 +137,9 @@ assertType<typeof timePickerProps.onChange>((_event: TimePickerChangeEvent) => {
 const loginOverlayProps = React.createElement(LoginOverlay, {}).props;
 
 assertType<LoginOverlayElement['autofocus'] | undefined>(loginOverlayProps.autofocus);
+type LoginOverlayProps = typeof loginOverlayProps;
+
+assertType<string | undefined>(loginOverlayProps.title);
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('style');
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('contentEditable');
+assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('onClick');


### PR DESCRIPTION
## Description

Manual cherry-pick of #200 to `2.3` branch.

## Type of change

- Cherry-pick