### PR TITLE
fix: support ReactElement as ContextMenu items

### DIFF
--- a/dev/pages/ContextMenu.tsx
+++ b/dev/pages/ContextMenu.tsx
@@ -1,0 +1,46 @@
+import { ContextMenu } from '../../src/ContextMenu.js';
+import { Icon } from '../../src/Icon.js';
+import '@vaadin/icons';
+
+const items = [
+  {
+    component: (
+      <>
+        <Icon
+          icon="vaadin:user"
+          style={{
+            color: 'var(--lumo-secondary-text-color)',
+            marginInlineEnd: 'var(--lumo-space-s)',
+            padding: 'var(--lumo-space-xs)',
+          }}
+        />
+        <span>Menu Item 1</span>
+      </>
+    ),
+  },
+  { component: 'hr' },
+  {
+    text: 'Menu Item 2',
+    children: [
+      { text: 'Menu Item 2-1' },
+      {
+        text: 'Menu Item 2-2',
+        children: [
+          { text: 'Menu Item 2-2-1' },
+          { text: 'Menu Item 2-2-2', disabled: true },
+          { component: 'hr' },
+          { text: 'Menu Item 2-2-3' },
+        ],
+      },
+    ],
+  },
+  { text: 'Menu Item 3', disabled: true },
+];
+
+export default function () {
+  return (
+    <ContextMenu items={items}>
+      <div style={{ padding: '10px' }}>Right click me</div>
+    </ContextMenu>
+  );
+}

--- a/src/ContextMenu.tsx
+++ b/src/ContextMenu.tsx
@@ -4,28 +4,40 @@ import {
   type ContextMenuRendererContext,
   type ContextMenuElement,
   type ContextMenuProps as _ContextMenuProps,
+  type ContextMenuItem as _ContextMenuItem,
 } from './generated/ContextMenu.js';
 import { type ReactContextRendererProps, useContextRenderer } from './renderers/useContextRenderer.js';
+import { mapItemsWithComponents } from './utils/mapItemsWithComponents.js';
 
 export * from './generated/ContextMenu.js';
 
 export type ContextMenuReactRendererProps = ReactContextRendererProps<ContextMenuRendererContext, ContextMenuElement>;
 
+export type ContextMenuItem = Omit<_ContextMenuItem, 'component' | 'children'> & {
+  component?: ReactElement | string;
+
+  children?: Array<ContextMenuItem>;
+};
+
 // The 'opened' property is omitted because it is readonly in the web component.
 // So you cannot set it up manually, only read from the component.
 // For changing the property, use specific methods of the component.
-export type ContextMenuProps = Partial<Omit<_ContextMenuProps, 'opened' | 'renderer'>> &
+export type ContextMenuProps = Partial<Omit<_ContextMenuProps, 'opened' | 'renderer' | 'items'>> &
   Readonly<{
     renderer?: ComponentType<ContextMenuReactRendererProps> | null;
+
+    items?: Array<ContextMenuItem>;
   }>;
 
 function ContextMenu(props: ContextMenuProps, ref: ForwardedRef<ContextMenuElement>): ReactElement | null {
   const [portals, renderer] = useContextRenderer(props.renderer);
+  const [itemPortals, webComponentItems] = mapItemsWithComponents(props.items, 'vaadin-context-menu-item');
 
   return (
-    <_ContextMenu {...props} ref={ref} renderer={renderer}>
+    <_ContextMenu {...props} ref={ref} renderer={renderer} items={webComponentItems}>
       {props.children}
       {portals}
+      {itemPortals}
     </_ContextMenu>
   );
 }

--- a/src/utils/mapItemsWithComponents.ts
+++ b/src/utils/mapItemsWithComponents.ts
@@ -1,0 +1,55 @@
+import { type ReactElement, type ReactPortal } from 'react';
+import { createPortal } from 'react-dom';
+
+type ItemWithReactElementComponent<T> = T & {
+  component?: ReactElement | string;
+  children?: Array<ItemWithReactElementComponent<T>>;
+};
+
+type ItemWithHTMLElementComponent<T> = T & {
+  component?: HTMLElement | string;
+  children?: Array<ItemWithHTMLElementComponent<T>>;
+};
+
+/**
+ * This function transforms a hierarchical list of items, where each item may contain a React component,
+ * into a list of items where each React component is replaced with an HTMLElement.
+ *
+ * The React components are not simply removed, but are instead rendered into portals.
+ * The HTMLElements created for the portals have the given tag name.
+ */
+export function mapItemsWithComponents<T>(
+  items?: Array<ItemWithReactElementComponent<T>>,
+  wrapperTagName = 'div',
+): [Array<ReactPortal>, Array<ItemWithHTMLElementComponent<Omit<T, 'children' | 'component'>>> | undefined] {
+  const itemPortals: ReactPortal[] = [];
+
+  const webComponentItems = items?.map((item) => {
+    const { component, children, ...rest } = item;
+
+    // Recursively map children
+    const [childPortals, webComponentChildren] = mapItemsWithComponents(children, wrapperTagName);
+    itemPortals.push(...childPortals);
+
+    if (component && typeof component !== 'string') {
+      // Component is a React element, create a portal for it
+      const root = document.createElement(wrapperTagName);
+      itemPortals.push(createPortal(component, root));
+
+      return {
+        ...rest,
+        component: root,
+        children: webComponentChildren,
+      };
+    } else {
+      return {
+        // Component is a string, or undefined, add it as such
+        ...rest,
+        component,
+        children: webComponentChildren,
+      };
+    }
+  });
+
+  return [itemPortals, webComponentItems];
+}

--- a/test/ContextMenu.spec.tsx
+++ b/test/ContextMenu.spec.tsx
@@ -3,8 +3,8 @@ import { cleanup, render } from '@testing-library/react/pure.js';
 import chaiDom from 'chai-dom';
 import {
   ContextMenu,
-  type ContextMenuItem,
   type ContextMenuElement,
+  type ContextMenuItem,
   type ContextMenuReactRendererProps,
 } from '../src/ContextMenu.js';
 import { Item } from '../src/Item.js';
@@ -14,12 +14,34 @@ import createOverlayCloseCatcher from './utils/createOverlayCloseCatcher.js';
 
 useChaiPlugin(chaiDom);
 
-describe('ContextMenu', () => {
-  const overlayTag = 'vaadin-context-menu-overlay';
+const overlayTag = 'vaadin-context-menu-overlay';
+const menuItemTag = 'vaadin-context-menu-item';
 
+async function until(predicate: () => boolean) {
+  while (!predicate()) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function menuAnimationComplete() {
+  await until(() => !document.querySelector(`${overlayTag}[opening]`));
+}
+
+async function openContextMenu(target: EventTarget) {
+  // Emulate right mouse click
+  target.dispatchEvent(new PointerEvent('contextmenu', { bubbles: true }));
+  await menuAnimationComplete();
+}
+
+async function openSubMenu(parentItem: EventTarget) {
+  parentItem.dispatchEvent(new PointerEvent('mouseover', { bubbles: true }));
+  await menuAnimationComplete();
+}
+
+describe('ContextMenu', () => {
   const [ref, catcher] = createOverlayCloseCatcher<ContextMenuElement>(overlayTag, (ref) => ref.close());
 
-  const items: ContextMenuItem[] = [{ text: 'Bar' }];
+  const items: Array<ContextMenuItem> = [{ text: 'Bar' }];
 
   function Renderer({ context }: ContextMenuReactRendererProps) {
     return (
@@ -34,8 +56,7 @@ describe('ContextMenu', () => {
   }
 
   async function assert(container: HTMLDivElement) {
-    // Emulate right mouse click
-    container.dispatchEvent(new PointerEvent('contextmenu', { bubbles: true }));
+    await openContextMenu(container);
 
     const menu = document.querySelector(overlayTag);
     expect(menu).to.exist;
@@ -66,5 +87,51 @@ describe('ContextMenu', () => {
     );
 
     await assert(container.querySelector<HTMLDivElement>('#actor')!);
+  });
+
+  it('should render the given text as an item', async () => {
+    const { container } = render(
+      <ContextMenu ref={ref} items={[{ text: 'foo' }]}>
+        <div id="target">target</div>
+      </ContextMenu>,
+    );
+
+    const target = container.querySelector<HTMLDivElement>('#target')!;
+    await openContextMenu(target);
+
+    const item = document.querySelector(`${overlayTag} ${menuItemTag}`);
+    expect(item?.firstElementChild).not.to.exist;
+    expect(item).to.have.text('foo');
+  });
+
+  it('should render the given ReactElement as an item', async () => {
+    const { container } = render(
+      <ContextMenu ref={ref} items={[{ component: <span>foo</span> }]}>
+        <div id="target">target</div>
+      </ContextMenu>,
+    );
+
+    const target = container.querySelector<HTMLDivElement>('#target')!;
+    await openContextMenu(target);
+
+    const item = document.querySelector(`${overlayTag} ${menuItemTag} > span`);
+    expect(item).to.have.text('foo');
+  });
+
+  it('should render the given ReactElement in a hierarchical menu as an item', async () => {
+    const { container } = render(
+      <ContextMenu ref={ref} items={[{ text: 'parent', children: [{ component: <span>foo</span> }] }]}>
+        <div id="target">target</div>
+      </ContextMenu>,
+    );
+
+    const target = container.querySelector<HTMLDivElement>('#target')!;
+    await openContextMenu(target);
+
+    const rootItem = document.querySelector(`${overlayTag} ${menuItemTag}`)!;
+    await openSubMenu(rootItem);
+
+    const item = document.querySelector(`${overlayTag} ${menuItemTag} > span`);
+    expect(item).to.have.text('foo');
   });
 });

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -1,4 +1,10 @@
-import React, { type ComponentType, type DOMAttributes, type HTMLAttributes, type RefAttributes } from 'react';
+import React, {
+  type ComponentType,
+  type DOMAttributes,
+  type HTMLAttributes,
+  type ReactElement,
+  type RefAttributes,
+} from 'react';
 import { TextField, TextFieldElement } from '../../TextField.js';
 import type { LitElement } from 'lit';
 import { GridColumn, GridColumnElement } from '../../GridColumn.js';
@@ -19,6 +25,7 @@ import { TimePicker, type TimePickerChangeEvent } from '../../TimePicker.js';
 import { TextArea, TextAreaElement, type TextAreaChangeEvent } from '../../TextArea.js';
 import { MessageInput, MessageInputElement, type MessageInputSubmitEvent } from '../../MessageInput.js';
 import { ComboBox, type ComboBoxChangeEvent } from '../../ComboBox.js';
+import { ContextMenu, type ContextMenuItem } from '../../ContextMenu.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
@@ -194,3 +201,8 @@ assertType<string | undefined>(loginOverlayProps.title);
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('style');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('contentEditable');
 assertOmitted<HTMLAttributes<LoginOverlayElement>, LoginOverlayProps>('onClick');
+
+const contextMenuProps = React.createElement(ContextMenu, {}).props;
+
+assertType<ReactElement | string | undefined>(contextMenuProps.items![0].component);
+assertType<ContextMenuItem[]>(contextMenuProps.items!);


### PR DESCRIPTION
## Description

Fix the support for using custom content / React components in `ContextMenu` items.

![Screenshot 2023-12-21 at 12 38 28](https://github.com/vaadin/react-components/assets/1222264/02bce84b-0f35-482b-8b1c-9a9598c1ae7b)


Part of https://github.com/vaadin/react-components/issues/54

## Type of change

Bugfix