### PR TITLE
fix: support ReactElement as MenuBar items

### DIFF
--- a/dev/pages/MenuBar.tsx
+++ b/dev/pages/MenuBar.tsx
@@ -1,4 +1,4 @@
-import { MenuBar } from '../../src/MenuBar.js';
+import { MenuBar, type MenuBarItem } from '../../src/MenuBar.js';
 import { Tooltip } from '../../src/Tooltip.js';
 import { Icon } from '../../src/Icon.js';
 import '@vaadin/icons';
@@ -9,7 +9,7 @@ const iconStyle = {
   marginRight: 'var(--lumo-space-s)',
 };
 
-const items = [
+const items: MenuBarItem[] = [
   { text: 'View', tooltip: 'Options for how to view the content' },
   { text: 'Edit' },
   {

--- a/dev/pages/MenuBar.tsx
+++ b/dev/pages/MenuBar.tsx
@@ -1,0 +1,58 @@
+import { MenuBar } from '../../src/MenuBar.js';
+import { Tooltip } from '../../src/Tooltip.js';
+import { Icon } from '../../src/Icon.js';
+import '@vaadin/icons';
+
+const iconStyle = {
+  width: 'var(--lumo-icon-size-m)',
+  height: 'var(--lumo-icon-size-m)',
+  marginRight: 'var(--lumo-space-s)',
+};
+
+const items = [
+  { text: 'View', tooltip: 'Options for how to view the content' },
+  { text: 'Edit' },
+  {
+    text: 'Share',
+    children: [
+      {
+        text: 'On social media',
+        children: [{ text: 'Facebook' }, { text: 'Twitter' }, { text: 'Instagram' }],
+      },
+      { text: 'By email' },
+      { text: 'Get link' },
+    ],
+  },
+  {
+    text: 'Move',
+    tooltip: 'Move to a different folder or trash.',
+    children: [
+      {
+        checked: true,
+        component: (
+          <>
+            <Icon icon="vaadin:folder" style={iconStyle} />
+            <span>To folder</span>
+          </>
+        ),
+      },
+      {
+        component: (
+          <>
+            <Icon icon="vaadin:trash" style={iconStyle} />
+            <span>To trash</span>
+          </>
+        ),
+      },
+    ],
+  },
+  { text: 'Duplicate', tooltip: 'Create a duplicate' },
+];
+
+export default function () {
+  return (
+    <MenuBar items={items}>
+      <Tooltip slot="tooltip" hover-delay="500" hide-delay="500" />
+    </MenuBar>
+  );
+}

--- a/src/MenuBar.ts
+++ b/src/MenuBar.ts
@@ -1,1 +1,0 @@
-export * from './generated/MenuBar.js';

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -1,0 +1,36 @@
+import { type ForwardedRef, forwardRef, type ReactElement } from 'react';
+import {
+  MenuBar as _MenuBar,
+  type MenuBarElement,
+  type MenuBarProps as _MenuBarProps,
+  type MenuBarItem as _MenuBarItem,
+} from './generated/MenuBar.js';
+import { mapItemsWithComponents } from './utils/mapItemsWithComponents.js';
+
+export * from './generated/MenuBar.js';
+
+export type MenuBarItem = Omit<_MenuBarItem, 'component' | 'children'> & {
+  component?: ReactElement | string;
+
+  children?: Array<MenuBarItem>;
+};
+
+export type MenuBarProps = Partial<Omit<_MenuBarProps, 'items'>> &
+  Readonly<{
+    items?: Array<MenuBarItem>;
+  }>;
+
+function MenuBar(props: MenuBarProps, ref: ForwardedRef<MenuBarElement>): ReactElement | null {
+  const [itemPortals, webComponentItems] = mapItemsWithComponents(props.items, 'vaadin-menu-bar-item');
+
+  return (
+    <_MenuBar {...props} ref={ref} items={webComponentItems}>
+      {props.children}
+      {itemPortals}
+    </_MenuBar>
+  );
+}
+
+const ForwardedMenuBar = forwardRef(MenuBar);
+
+export { ForwardedMenuBar as MenuBar };

--- a/src/MenuBar.tsx
+++ b/src/MenuBar.tsx
@@ -4,15 +4,22 @@ import {
   type MenuBarElement,
   type MenuBarProps as _MenuBarProps,
   type MenuBarItem as _MenuBarItem,
+  type SubMenuItem as _SubMenuItem,
 } from './generated/MenuBar.js';
 import { mapItemsWithComponents } from './utils/mapItemsWithComponents.js';
 
 export * from './generated/MenuBar.js';
 
+export type SubMenuItem = Omit<_SubMenuItem, 'component' | 'children'> & {
+  component?: ReactElement | string;
+
+  children?: Array<SubMenuItem>;
+};
+
 export type MenuBarItem = Omit<_MenuBarItem, 'component' | 'children'> & {
   component?: ReactElement | string;
 
-  children?: Array<MenuBarItem>;
+  children?: Array<SubMenuItem>;
 };
 
 export type MenuBarProps = Partial<Omit<_MenuBarProps, 'items'>> &

--- a/test/MenuBar.spec.tsx
+++ b/test/MenuBar.spec.tsx
@@ -1,0 +1,63 @@
+import { expect, use as useChaiPlugin } from '@esm-bundle/chai';
+import { render } from '@testing-library/react/pure.js';
+import chaiDom from 'chai-dom';
+import { MenuBar } from '../src/MenuBar.js';
+
+useChaiPlugin(chaiDom);
+
+const overlayTag = 'vaadin-menu-bar-overlay';
+const menuItemTag = 'vaadin-menu-bar-item';
+const menuButtonTag = 'vaadin-menu-bar-button';
+
+async function until(predicate: () => boolean) {
+  while (!predicate()) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+async function menuAnimationComplete() {
+  await new Promise((r) => requestAnimationFrame(r));
+  await until(
+    () => !document.querySelector(`${overlayTag}[opening]`) && !!document.querySelector(`${overlayTag}[opened]`),
+  );
+}
+
+async function openRootItemSubMenu(rootMenuItem: EventTarget) {
+  rootMenuItem.dispatchEvent(new PointerEvent('click', { bubbles: true }));
+  await menuAnimationComplete();
+}
+
+describe('MenuBar', () => {
+  it('should render the given text as an item', async () => {
+    const { container } = render(<MenuBar items={[{ text: 'foo' }]} />);
+
+    const menuBar = container.querySelector<HTMLDivElement>('vaadin-menu-bar')!;
+
+    const item = menuBar.querySelector(menuButtonTag);
+    expect(item?.firstElementChild).not.to.exist;
+    expect(item).to.have.text('foo');
+  });
+
+  it('should render the given ReactElement as an item', async () => {
+    const { container } = render(<MenuBar items={[{ component: <span>foo</span> }]} />);
+
+    const menuBar = container.querySelector<HTMLDivElement>('vaadin-menu-bar')!;
+
+    const item = menuBar.querySelector(`${menuItemTag} > span`);
+    expect(item).to.have.text('foo');
+  });
+
+  it('should render the given ReactElement in a hierarchical menu as an item', async () => {
+    const { container } = render(
+      <MenuBar items={[{ text: 'parent', children: [{ component: <span>foo</span> }] }]}></MenuBar>,
+    );
+
+    const menuBar = container.querySelector<HTMLDivElement>('vaadin-menu-bar')!;
+
+    const rootItem = menuBar.querySelector(menuButtonTag)!;
+    await openRootItemSubMenu(rootItem);
+
+    const item = document.querySelector(`${overlayTag} ${menuItemTag} > span`);
+    expect(item).to.have.text('foo');
+  });
+});

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -27,6 +27,7 @@ import { MessageInput, MessageInputElement, type MessageInputSubmitEvent } from 
 import { ComboBox, type ComboBoxChangeEvent } from '../../ComboBox.js';
 import { ContextMenu, type ContextMenuItem } from '../../ContextMenu.js';
 import { MenuBar, type MenuBarItem } from '../../MenuBar.js';
+import type { SubMenuItem } from '../../src/MenuBar.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
@@ -210,4 +211,7 @@ assertType<ContextMenuItem[]>(contextMenuProps.items!);
 
 const menuBarProps = React.createElement(MenuBar, {}).props;
 assertType<ReactElement | string | undefined>(menuBarProps.items![0].component);
-assertType<MenuBarItem[]>(menuBarProps.items!);
+assertType<MenuBarItem[] | undefined>(menuBarProps.items);
+assertType<boolean | undefined>(menuBarProps.items![0].children![0].checked);
+assertOmitted<SubMenuItem, MenuBarItem>('checked');
+assertType<SubMenuItem[] | undefined>(menuBarProps.items![0].children);

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -26,6 +26,7 @@ import { TextArea, TextAreaElement, type TextAreaChangeEvent } from '../../TextA
 import { MessageInput, MessageInputElement, type MessageInputSubmitEvent } from '../../MessageInput.js';
 import { ComboBox, type ComboBoxChangeEvent } from '../../ComboBox.js';
 import { ContextMenu, type ContextMenuItem } from '../../ContextMenu.js';
+import { MenuBar, type MenuBarItem } from '../../MenuBar.js';
 
 const assertType = <TExpected>(value: TExpected) => value;
 const assertOmitted = <C, T>(prop: keyof Omit<C, keyof T>) => prop;
@@ -206,3 +207,7 @@ const contextMenuProps = React.createElement(ContextMenu, {}).props;
 
 assertType<ReactElement | string | undefined>(contextMenuProps.items![0].component);
 assertType<ContextMenuItem[]>(contextMenuProps.items!);
+
+const menuBarProps = React.createElement(MenuBar, {}).props;
+assertType<ReactElement | string | undefined>(menuBarProps.items![0].component);
+assertType<MenuBarItem[]>(menuBarProps.items!);


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/react-components/pull/204

Fix the support for using custom content / React components in `MenuBar` items.

![Screenshot 2023-12-21 at 13 44 58](https://github.com/vaadin/react-components/assets/1222264/7a592027-2539-4df4-8507-ab31b2c6cfb8)


Fixes https://github.com/vaadin/react-components/issues/54

## Type of change

Bugfix