### PR TITLE
chore: deprecate grid column header/footer renderers

### DIFF
--- a/src/GridColumn.tsx
+++ b/src/GridColumn.tsx
@@ -38,8 +38,14 @@ export type GridColumnProps<TItem> = Partial<
   Readonly<{
     children?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     header?: ReactNode;
+    /**
+     * @deprecated Use `header` instead.
+     */
     headerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     renderer?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
   }>;

--- a/src/GridColumnGroup.tsx
+++ b/src/GridColumnGroup.tsx
@@ -25,8 +25,14 @@ export type GridColumnGroupProps = Partial<
 > &
   Readonly<{
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<ReactSimpleRendererProps<GridColumnGroupElement>> | null;
     header?: ReactNode;
+    /**
+     * @deprecated Use `header` instead.
+     */
     headerRenderer?: ComponentType<ReactSimpleRendererProps<GridColumnGroupElement>> | null;
   }>;
 

--- a/src/GridFilterColumn.tsx
+++ b/src/GridFilterColumn.tsx
@@ -32,6 +32,9 @@ export type GridFilterColumnProps<TItem> = Partial<
   Readonly<{
     children?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     renderer?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
   }>;

--- a/src/GridProEditColumn.tsx
+++ b/src/GridProEditColumn.tsx
@@ -37,8 +37,14 @@ export type GridProEditColumnProps<TItem> = Partial<
     children?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
     editModeRenderer?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     header?: ReactNode;
+    /**
+     * @deprecated Use `header` instead.
+     */
     headerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     renderer?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
   }>;

--- a/src/GridSelectionColumn.tsx
+++ b/src/GridSelectionColumn.tsx
@@ -15,7 +15,6 @@ import {
 import type { GridBodyReactRendererProps, GridEdgeReactRendererProps } from './renderers/grid.js';
 import { useModelRenderer } from './renderers/useModelRenderer.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
-import { useSimpleRenderer } from './renderers/useSimpleRenderer.js';
 import type { OmittedGridColumnHTMLAttributes } from './GridColumn.js';
 
 export * from './generated/GridSelectionColumn.js';
@@ -23,22 +22,34 @@ export * from './generated/GridSelectionColumn.js';
 export type GridSelectionColumnProps<TItem> = Partial<
   Omit<
     _GridSelectionColumnProps<TItem>,
-    'children' | 'footerRenderer' | 'headerRenderer' | 'renderer' | keyof OmittedGridColumnHTMLAttributes<TItem>
+    | 'children'
+    | 'footerRenderer'
+    | 'headerRenderer'
+    | 'renderer'
+    | 'header'
+    | keyof OmittedGridColumnHTMLAttributes<TItem>
   >
 > &
   Readonly<{
     children?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
+    header?: ReactNode;
+    /**
+     * @deprecated Use `header` instead.
+     */
     headerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     renderer?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
   }>;
 
 function GridSelectionColumn<TItem = GridDefaultItem>(
-  { footer, ...props }: GridSelectionColumnProps<TItem>,
+  { footer, header, ...props }: GridSelectionColumnProps<TItem>,
   ref: ForwardedRef<GridSelectionColumnElement<TItem>>,
 ): ReactElement | null {
-  const [headerPortals, headerRenderer] = useSimpleRenderer(props.headerRenderer, {
+  const [headerPortals, headerRenderer] = useSimpleOrChildrenRenderer(props.headerRenderer, header, {
     renderSync: true,
   });
   const [footerPortals, footerRenderer] = useSimpleOrChildrenRenderer(props.footerRenderer, footer, {

--- a/src/GridSortColumn.tsx
+++ b/src/GridSortColumn.tsx
@@ -31,6 +31,9 @@ export type GridSortColumnProps<TItem> = Partial<
   Readonly<{
     children?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     renderer?: ComponentType<GridBodyReactRendererProps<TItem>> | null;
   }>;

--- a/src/GridTreeColumn.tsx
+++ b/src/GridTreeColumn.tsx
@@ -31,8 +31,14 @@ export type GridTreeColumnProps<TItem> = Partial<
 > &
   Readonly<{
     footer?: ReactNode;
+    /**
+     * @deprecated Use `footer` instead.
+     */
     footerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
     header?: ReactNode;
+    /**
+     * @deprecated Use `header` instead.
+     */
     headerRenderer?: ComponentType<GridEdgeReactRendererProps<TItem>> | null;
   }>;
 

--- a/test/Grid.spec.tsx
+++ b/test/Grid.spec.tsx
@@ -289,20 +289,23 @@ describe('Grid', () => {
       expect(bodyCell2).to.have.text('Ringo');
     });
 
-    it('should support setting footer component', async () => {
+    it('should support setting header and footer component', async () => {
       render(
         <Grid<Item> items={items}>
-          <GridSelectionColumn footer={<i>Footer</i>}>{DefaultBodyRenderer}</GridSelectionColumn>
+          <GridSelectionColumn header={<i>Header</i>} footer={<i>Footer</i>}>
+            {DefaultBodyRenderer}
+          </GridSelectionColumn>
         </Grid>,
       );
 
       const [columns, cells] = await getGridMeaningfulParts('vaadin-grid-selection-column');
       expect(columns).to.have.length(1);
-      expect(cells).to.have.length(3);
+      expect(cells).to.have.length(4);
 
-      const footerCell = cells[0];
+      const [headerCell, footerCell] = cells;
 
       expect(footerCell).to.have.text('Footer');
+      expect(headerCell).to.have.text('Header');
     });
   });
 


### PR DESCRIPTION
## Description

Deprecate `headerRenderer` and `footerRenderer` in favor of `header` and `footer` in Grid column types.

Closes https://github.com/vaadin/react-components/issues/146

## Type of change

Chore