### PR TITLE
fix: import GridColumnElement from the correct file

### DIFF
--- a/src/GridProEditColumn.tsx
+++ b/src/GridProEditColumn.tsx
@@ -7,7 +7,8 @@ import {
   type RefAttributes,
   createElement,
 } from 'react';
-import type { GridBodyRenderer, GridColumn, GridDefaultItem } from './generated/Grid.js';
+import type { GridBodyRenderer, GridDefaultItem } from './generated/Grid.js';
+import type { GridColumnElement } from './generated/GridColumn.js';
 import {
   GridProEditColumn as _GridProEditColumn,
   type GridProEditColumnElement,
@@ -79,7 +80,7 @@ function editColumnRenderer(bodyRenderer?: (GridBodyRenderer & { __wrapperRender
 
   bodyRenderer.__wrapperRenderer ||= (
     root: EditColumnRendererRoot,
-    column: GridColumn & {
+    column: GridColumnElement & {
       __originalClearCellContent?: ClearFunction;
       _clearCellContent?: ClearFunction;
     },


### PR DESCRIPTION
## Description

This PR fixes the following error in the release build:

```
npm ERR! [dts] src/GridProEditColumn.tsx(10,33): error TS2305: Module '"./generated/Grid.js"' has no exported member 'GridColumn'.
npm ERR! [dts] src/GridProEditColumn.tsx(93,35): error TS7006: Parameter 'cell' implicitly has an 'any' type.
```

## Type of change

- Bugfix