### PR TITLE
fix: manually relocate built util files

### DIFF
--- a/packages/react-components-pro/package.json
+++ b/packages/react-components-pro/package.json
@@ -128,6 +128,8 @@
     "./Map": "./Map.js",
     "./RichTextEditor": "./RichTextEditor.js",
     "./utils/createComponent.d.ts": "./utils/createComponent.d.ts",
-    "./utils/createComponent.d.ts.map": "./utils/createComponent.d.ts.map"
+    "./utils/createComponent.d.ts.map": "./utils/createComponent.d.ts.map",
+    "./utils/createComponent.js": "./utils/createComponent.js",
+    "./utils/createComponent.js.map": "./utils/createComponent.js.map"
   }
 }

--- a/scripts/validate-build.ts
+++ b/scripts/validate-build.ts
@@ -73,4 +73,23 @@ async function hasCopiedDts() {
   }
 }
 
-await Promise.all([validateInheritedProperties(), hasGeneratedDir(), hasNoCssDir(), hasCopiedDts()]);
+/**
+ * Validates that the components have /utils/createComponent.js file
+ */
+async function hasCreateComponent() {
+  if (!existsSync(resolve(packagesDir, corePackage, 'utils', 'createComponent.js'))) {
+    throw new Error(`The utils/createComponent.js file does not exist in the core package.`);
+  }
+
+  if (!existsSync(resolve(packagesDir, proPackage, 'utils', 'createComponent.js'))) {
+    throw new Error(`The utils/createComponent.js file does not exist in the pro package.`);
+  }
+}
+
+await Promise.all([
+  validateInheritedProperties(),
+  hasGeneratedDir(),
+  hasNoCssDir(),
+  hasCopiedDts(),
+  hasCreateComponent(),
+]);


### PR DESCRIPTION
## Description

For some reason, under `react-components-pro` package, the `build.ts` script generates output files to the package root, ignoring the dir name under which the source file is.

As a workaround, manually move the files to the correct location.

## Type of change

Bugfix