### PR TITLE
fix: commit package updates with version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "validate:types": "tsc --noEmit",
     "validate:prettier": "prettier -c scripts packages/**/src/*.ts packages/**/src/{utils,renderers}/*.ts test types karma.config.cjs vite.config.ts",
     "validate:build": "tsx scripts/validate-build.ts",
-    "version": "npm run version -ws && npm install --package-lock-only --ignore-scripts"
+    "version": "npm run version -ws && git add packages/**/package.json && npm install --package-lock-only --ignore-scripts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Make sure `npm version` includes the version updates to `packages/.../package.json` in the commit.

[Here's](https://github.com/vaadin/react-components/commit/17edcfa399f45bb293549418c60551069e3d0193) an example of a version bump which only included changes to root level `package.json` and the lock file.

## Type of change

Bugfix