### PR TITLE
fix: clean up before post-version install

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "validate:types": "tsc --noEmit",
     "validate:prettier": "prettier -c scripts packages/**/src/*.ts packages/**/src/{utils,renderers}/*.ts test types karma.config.cjs vite.config.ts",
     "validate:build": "tsx scripts/validate-build.ts",
-    "version": "npm run version -ws && git add packages/**/package.json && npm install --package-lock-only --ignore-scripts"
+    "version": "npm run version -ws && git add packages/**/package.json && rimraf package-lock.json node_modules && npm install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Clean up the old lock file and `node_modules` before re-installing after version bump.