### PR TITLE
test: fix failing tests after web components changes

### DIFF
--- a/test/Dialog.spec.tsx
+++ b/test/Dialog.spec.tsx
@@ -19,15 +19,20 @@ describe('Dialog', () => {
     const dialog = document.querySelector(overlayTag);
     expect(dialog).to.exist;
 
-    const [header, footer, body] = Array.from(dialog!.childNodes);
+    const childNodes = Array.from(dialog!.childNodes);
 
+    const header = childNodes.find(
+      (node) => node.nodeType === Node.ELEMENT_NODE && (node as Element).getAttribute('slot') === 'header-content',
+    );
     expect(header).to.exist;
     expect(header).to.have.text('Title');
 
-    expect(footer).to.exist;
+    const footer = childNodes.find(
+      (node) => node.nodeType === Node.ELEMENT_NODE && (node as Element).getAttribute('slot') === 'footer',
+    );
     expect(footer).to.have.text('Footer');
 
-    expect(body).to.exist;
+    const body = childNodes.find((node) => node.nodeType === Node.TEXT_NODE);
     expect(body).to.have.text('FooBar');
   }
 

--- a/test/MenuBar.spec.tsx
+++ b/test/MenuBar.spec.tsx
@@ -33,6 +33,7 @@ describe('MenuBar', () => {
     const { container } = render(<MenuBar items={[{ text: 'foo' }]} />);
 
     const menuBar = container.querySelector<HTMLDivElement>('vaadin-menu-bar')!;
+    await until(() => !!menuBar.querySelector(`${menuButtonTag}:not([slot])`));
 
     const item = menuBar.querySelector(menuButtonTag);
     expect(item?.firstElementChild).not.to.exist;
@@ -43,6 +44,7 @@ describe('MenuBar', () => {
     const { container } = render(<MenuBar items={[{ component: <span>foo</span> }]} />);
 
     const menuBar = container.querySelector<HTMLDivElement>('vaadin-menu-bar')!;
+    await until(() => !!menuBar.querySelector(`${menuButtonTag}:not([slot])`));
 
     const item = menuBar.querySelector(`${menuItemTag} > span`);
     expect(item).to.have.text('foo');
@@ -54,6 +56,7 @@ describe('MenuBar', () => {
     );
 
     const menuBar = container.querySelector<HTMLDivElement>('vaadin-menu-bar')!;
+    await until(() => !!menuBar.querySelector(`${menuButtonTag}:not([slot])`));
 
     const rootItem = menuBar.querySelector(menuButtonTag)!;
     await openRootItemSubMenu(rootItem);
@@ -69,6 +72,7 @@ describe('MenuBar', () => {
     const { container } = render(<MenuBar items={items} onItemSelected={spy}></MenuBar>);
 
     const menuBar = container.querySelector<MenuBarElement>('vaadin-menu-bar')!;
+    await until(() => !!menuBar.querySelector(`${menuButtonTag}:not([slot])`));
 
     const rootItems = Array.from(menuBar.querySelectorAll<HTMLElement>(menuButtonTag));
     rootItems[0].click();


### PR DESCRIPTION
## Description

Updated some failing tests after recent changes in the web components:

- `MenuBar` tests needs to wait for the initial items to be rendered due to https://github.com/vaadin/web-components/pull/7312
- `Dialog` tests now render content in the different order, possibly a side-effect of https://github.com/vaadin/web-components/pull/7313 (not sure as it's footer / header order that changed)

## Type of change

- Tests