### PR TITLE
fix: handle backslash in font-icons when generating CSS

### DIFF
--- a/scripts/css-generator.ts
+++ b/scripts/css-generator.ts
@@ -164,7 +164,10 @@ function shimThemableMixin(moduleId: string) {
   return shimModule(themableMixin, {
     ...themableMixinModule,
     css(strings: readonly string[], ...values: ReadonlyArray<CSSResult | number>) {
-      return new CSSResult(moduleId, strings, values);
+      const result: readonly string[] = moduleId.endsWith('font-icons.js')
+        ? strings.map((string) => string.replace(/'\\\\([a-z0-9]+)'/g, "'\\$1'"))
+        : strings;
+      return new CSSResult(moduleId, result, values);
     },
     registerStyles() {},
     unsafeCSS,


### PR DESCRIPTION
## Description

Related to finding from https://github.com/vaadin/web-components/issues/7976#issuecomment-2418975229

This fixes the output of CSS generator script to look like the one we had in the [original repository](https://github.com/vaadin/vaadin-lumo-styles/blob/9e3e9aa62d1922fb6f441a53866b51a7ceef791a/font-icons.html#L14).

### Before

```css
  html {
    --lumo-icons-align-center: '\\ea01';
    --lumo-icons-align-left: '\\ea02';
    --lumo-icons-align-right: '\\ea03';
    /* ... */
  }
```

### After

```css
  html {
    --lumo-icons-align-center: '\ea01';
    --lumo-icons-align-left: '\ea02';
    --lumo-icons-align-right: '\ea03';
    /* ... */
  }
```

## Type of change

- Bugfix

## Note

Can be tested by running the following npm script:

```sh
npm run build:generate-css -w @vaadin/react-components
```