### PR TITLE
refactor: enable virtual list event map generic type

### DIFF
--- a/scripts/utils/settings.ts
+++ b/scripts/utils/settings.ts
@@ -27,7 +27,7 @@ export const genericElements = new Map<string, GenericElementInfo>([
   ['GridSortColumn', { numberOfGenerics: 1, nonGenericInterfaces: [NonGenericInterface.EVENT_MAP] }],
   ['GridTreeColumn', { numberOfGenerics: 1, nonGenericInterfaces: [NonGenericInterface.EVENT_MAP] }],
   ['MultiSelectComboBox', { numberOfGenerics: 1 }],
-  ['VirtualList', { numberOfGenerics: 1, nonGenericInterfaces: [NonGenericInterface.EVENT_MAP] }],
+  ['VirtualList', { numberOfGenerics: 1 }],
 ]);
 
 export type EventSettings = Readonly<{


### PR DESCRIPTION
## Description

Enable virtual list event map generic type.

Part of https://github.com/vaadin/platform/issues/6838

Depends on https://github.com/vaadin/web-components/pull/8318

## Type of change

Feature