### PR TITLE
chore: downgrade type-fest to 4.30.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "simple-git-hooks": "^2.11.1",
         "sinon": "^19.0.2",
         "tsx": "^4.19.2",
-        "type-fest": "^4.30.0",
+        "type-fest": "4.30.1",
         "typescript": "^5.7.2",
         "vite": "^5.4.11"
       }
@@ -4435,6 +4435,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.3.tgz",
       "integrity": "sha512-iOKdzTUWEVM4nlxpFudFsWyUiu/Jakkga4OZPEt7CGoSEsAsUgdOZqR6pcgx2STBek9Gm4hcarJpXSzIvZ/hKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.5.5",
         "@types/json-schema": "^7.0.15",
@@ -6863,6 +6864,7 @@
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
       "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.4.2",
         "picomatch": "^4.0.2"
@@ -6876,6 +6878,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
       "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -6890,6 +6893,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6971,10 +6975,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.30.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.2.tgz",
-      "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.1.tgz",
+      "integrity": "sha512-ojFL7eDMX2NF0xMbDwPZJ8sb7ckqtlAi1GsmgsFXvErT9kFTk1r0DuQKvrCh73M6D4nngeHJmvogF9OluXs7Hw==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -7000,6 +7005,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12878,9 +12884,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "4.30.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.2.tgz",
-      "integrity": "sha512-UJShLPYi1aWqCdq9HycOL/gwsuqda1OISdBO3t8RlXQC4QvtuIz4b5FCfe2dQIWEpmlRExKmcTBfP1r9bhY7ig==",
+      "version": "4.30.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.1.tgz",
+      "integrity": "sha512-ojFL7eDMX2NF0xMbDwPZJ8sb7ckqtlAi1GsmgsFXvErT9kFTk1r0DuQKvrCh73M6D4nngeHJmvogF9OluXs7Hw==",
       "dev": true
     },
     "type-is": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "simple-git-hooks": "^2.11.1",
     "sinon": "^19.0.2",
     "tsx": "^4.19.2",
-    "type-fest": "^4.30.0",
+    "type-fest": "4.30.1",
     "typescript": "^5.7.2",
     "vite": "^5.4.11"
   },


### PR DESCRIPTION
## Description

The `type-fest` was upgraded to `4.30.2` in https://github.com/vaadin/react-components/pull/279. However, this version causes TypeScript errors when running `npm run validate:types` due to https://github.com/sindresorhus/type-fest/issues/1013:

```
scripts/generator.ts:124:88 - error TS2345: Argument of type 'GenericJsContributions' is not assignable to parameter of type 'string'.
  Type 'number' is not assignable to type 'string'.
```

This PR temporarily downgrades `type-fest` to `4.30.1`, which doesn't have this issue.

## Type of change

- [x] Internal
