### PR TITLE
fix: specify explicit return type for components with forwardRef

### DIFF
--- a/packages/react-components/src/ContextMenu.tsx
+++ b/packages/react-components/src/ContextMenu.tsx
@@ -1,4 +1,11 @@
-import { type ComponentType, type ForwardedRef, forwardRef, type ReactElement } from 'react';
+import {
+  type ComponentType,
+  type ForwardedRef,
+  type ForwardRefExoticComponent,
+  forwardRef,
+  type ReactElement,
+  type RefAttributes,
+} from 'react';
 import {
   ContextMenu as _ContextMenu,
   type ContextMenuRendererContext,
@@ -63,6 +70,8 @@ function ContextMenu(props: ContextMenuProps, ref: ForwardedRef<ContextMenuEleme
   );
 }
 
-const ForwardedContextMenu = forwardRef(ContextMenu);
+const ForwardedContextMenu = forwardRef(ContextMenu) as ForwardRefExoticComponent<
+  ContextMenuProps & RefAttributes<ContextMenuElement>
+>;
 
 export { ForwardedContextMenu as ContextMenu };

--- a/packages/react-components/src/DateTimePicker.tsx
+++ b/packages/react-components/src/DateTimePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, type ForwardRefExoticComponent, type RefAttributes } from 'react';
 import {
   DateTimePicker as _DateTimePicker,
   type DateTimePickerElement,
@@ -10,4 +10,4 @@ export * from './generated/DateTimePicker.js';
 
 export const DateTimePicker = forwardRef(
   createComponentWithOrderedProps<DateTimePickerProps, DateTimePickerElement>(_DateTimePicker, 'value'),
-);
+) as ForwardRefExoticComponent<DateTimePickerProps & RefAttributes<DateTimePickerElement>>;

--- a/packages/react-components/src/Dialog.tsx
+++ b/packages/react-components/src/Dialog.tsx
@@ -1,10 +1,12 @@
 import {
   type ComponentType,
   type ForwardedRef,
+  type ForwardRefExoticComponent,
   type HTMLAttributes,
   forwardRef,
   type ReactElement,
   type ReactNode,
+  type RefAttributes,
 } from 'react';
 import { Dialog as _Dialog, type DialogElement, type DialogProps as _DialogProps } from './generated/Dialog.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
@@ -48,6 +50,6 @@ function Dialog(
   );
 }
 
-const ForwardedDialog = forwardRef(Dialog);
+const ForwardedDialog = forwardRef(Dialog) as ForwardRefExoticComponent<DialogProps & RefAttributes<DialogElement>>;
 
 export { ForwardedDialog as Dialog };

--- a/packages/react-components/src/MenuBar.tsx
+++ b/packages/react-components/src/MenuBar.tsx
@@ -1,4 +1,10 @@
-import { type ForwardedRef, forwardRef, type ReactElement } from 'react';
+import {
+  type ForwardedRef,
+  type ForwardRefExoticComponent,
+  forwardRef,
+  type ReactElement,
+  type RefAttributes,
+} from 'react';
 import {
   MenuBar as _MenuBar,
   type MenuBarElement,
@@ -54,6 +60,6 @@ function MenuBar(props: MenuBarProps, ref: ForwardedRef<MenuBarElement>): ReactE
   );
 }
 
-const ForwardedMenuBar = forwardRef(MenuBar);
+const ForwardedMenuBar = forwardRef(MenuBar) as ForwardRefExoticComponent<MenuBarProps & RefAttributes<MenuBarElement>>;
 
 export { ForwardedMenuBar as MenuBar };

--- a/packages/react-components/src/Popover.tsx
+++ b/packages/react-components/src/Popover.tsx
@@ -1,10 +1,12 @@
 import {
   type ComponentType,
   type ForwardedRef,
+  type ForwardRefExoticComponent,
   type HTMLAttributes,
   forwardRef,
   type ReactElement,
   type ReactNode,
+  type RefAttributes,
 } from 'react';
 import { Popover as _Popover, type PopoverElement, type PopoverProps as _PopoverProps } from './generated/Popover.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
@@ -35,6 +37,6 @@ function Popover({ children, ...props }: PopoverProps, ref: ForwardedRef<Popover
   );
 }
 
-const ForwardedPopover = forwardRef(Popover);
+const ForwardedPopover = forwardRef(Popover) as ForwardRefExoticComponent<PopoverProps & RefAttributes<PopoverElement>>;
 
 export { ForwardedPopover as Popover };

--- a/packages/react-components/src/Select.tsx
+++ b/packages/react-components/src/Select.tsx
@@ -1,10 +1,12 @@
 import {
   type ComponentType,
   type ForwardedRef,
+  type ForwardRefExoticComponent,
   forwardRef,
   isValidElement,
   type ReactElement,
   type ReactNode,
+  type RefAttributes,
   useEffect,
   useRef,
 } from 'react';
@@ -62,6 +64,6 @@ function Select(props: SelectProps, ref: ForwardedRef<SelectElement>): ReactElem
   );
 }
 
-const ForwardedSelect = forwardRef(Select);
+const ForwardedSelect = forwardRef(Select) as ForwardRefExoticComponent<SelectProps & RefAttributes<SelectElement>>;
 
 export { ForwardedSelect as Select };

--- a/packages/react-components/src/TimePicker.tsx
+++ b/packages/react-components/src/TimePicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, type ForwardRefExoticComponent, type ReactElement, type RefAttributes } from 'react';
 import { TimePicker as _TimePicker, type TimePickerElement, type TimePickerProps } from './generated/TimePicker.js';
 import createComponentWithOrderedProps from './utils/createComponentWithOrderedProps.js';
 
@@ -6,4 +6,4 @@ export * from './generated/TimePicker.js';
 
 export const TimePicker = forwardRef(
   createComponentWithOrderedProps<TimePickerProps, TimePickerElement>(_TimePicker, 'value'),
-);
+) as ForwardRefExoticComponent<TimePickerProps & RefAttributes<TimePickerElement>>;


### PR DESCRIPTION
## Description

Fixes #290 

This fixes the error with IntelliJ showing `ForwardRefExoticComponent<unknown>` for components like `Select`:

<img width="574" alt="Screenshot 2025-01-14 at 15 00 58" src="https://github.com/user-attachments/assets/b490edf3-fcbc-48e4-a79f-c2a35f7908c2" />


Here's the overview of the `.d.ts` output change:

#### Before

```ts
declare const ForwardedSelect: import("react").ForwardRefExoticComponent<Partial<Omit<Partial<import("./utils/createComponent.js").ThemedWebComponentProps<SelectElement, Readonly<{
    onValidated: import("@lit/react").EventName<import("@vaadin/select").SelectEventMap["validated"]>;
    onChange: import("@lit/react").EventName<import("@vaadin/select").SelectEventMap["change"]>;
    onInvalidChanged: import("@lit/react").EventName<import("@vaadin/select").SelectEventMap["invalid-changed"]>;
    onOpenedChanged: import("@lit/react").EventName<import("@vaadin/select").SelectEventMap["opened-changed"]>;
    onValueChanged: import("@lit/react").EventName<import("@vaadin/select").SelectEventMap["value-changed"]>;
}>>>, "children" | "renderer">> & Readonly<{
    children?: ReactNode | SelectRenderer | Array<ReactNode | SelectRenderer>;
    renderer?: SelectRenderer | null;
}> & import("react").RefAttributes<SelectElement>>;
```

#### After

```ts
declare const ForwardedSelect: ForwardRefExoticComponent<SelectProps & RefAttributes<SelectElement>>;
```

## Type of change

- Bugfix

## Note

When testing the change in `react-components` project itself, make sure you use import from the npm package:

```js
import { Select } from '@vaadin/react-components';
```

Otherwise, when using relative imports, the TS compiler produces correct types with the old version too.

```js
import { Select } from '../../packages/react-components/src/Select.js';
```