### PR TITLE
chore: update test and kitchen sink to work with React 19

### DIFF
--- a/dev/kitchen-sink/Row1.tsx
+++ b/dev/kitchen-sink/Row1.tsx
@@ -25,7 +25,7 @@ export default function Row1() {
           <div>Accordion content 2</div>
         </AccordionPanel>
       </Accordion>
-      <AvatarGroup prefix="Users: " items={[{ name: 'Jane Roe', abbr: 'JD' }]}></AvatarGroup>
+      <AvatarGroup items={[{ name: 'Jane Roe', abbr: 'JD' }]}></AvatarGroup>
       <Chart title="Chart" style={{ height: '300px' }}>
         <ChartSeries title="Items" type="bar" values={[10, 20, 30]}></ChartSeries>
       </Chart>

--- a/test/Popover.spec.tsx
+++ b/test/Popover.spec.tsx
@@ -15,6 +15,7 @@ describe('Popover', () => {
 
   async function assert() {
     await new Promise((r) => requestAnimationFrame(r));
+    await new Promise((r) => requestAnimationFrame(r));
 
     const overlay = document.querySelector(overlayTag);
     expect(overlay).to.exist;


### PR DESCRIPTION
Went through the repo to identify possible issues when using React 19. Could not find anything critical, automated tests pass and testing locally also worked fine.

The only things that needed changing were:
- One demo page passed the [`prefix` property](https://developer.mozilla.org/en-US/docs/Web/API/Element/prefix) to `AvatarGroup` which is read-only. React 19 apparently validates for that now and throws an error.
- One test required an additional delay 
