### PR TITLE
chore: simplify generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,9 @@
         "type-fest": "4.30.1",
         "typescript": "^5.7.2",
         "vite": "^5.4.11"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "type": "module",
   "version": "24.7.0-alpha9",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "build": "npm run build:load-schema && npm run build -w packages/react-components && npm run build -w packages/react-components-pro",
     "build:load-schema": "tsx scripts/schema-loader.ts",

--- a/packages/react-components-pro/tsconfig.build.json
+++ b/packages/react-components-pro/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": ".",
     "module": "NodeNext",
@@ -7,6 +7,5 @@
     "noEmit": false,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }

--- a/packages/react-components-pro/tsconfig.json
+++ b/packages/react-components-pro/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["es2021", "dom"]
+  },
+  "include": ["src"]
+}

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -17,7 +17,7 @@
     "build": "npm run build:dev && npm run build:code && npm run build:update-packagejson",
     "build:dev": "npm run build:generate && npm run build:generate-css",
     "build:generate": "tsx ../../scripts/generator.ts",
-    "build:generate-css": "tsx ../../scripts/css-generator.ts",
+    "build:generate-css": "tsx --experimental-vm-modules ../../scripts/css-generator.ts",
     "build:update-packagejson": "tsx ../../scripts/package-json-update.ts",
     "build:code": "concurrently npm:build:code:*",
     "build:code:ts": "tsx ../../scripts/build.ts",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -17,7 +17,7 @@
     "build": "npm run build:dev && npm run build:code && npm run build:update-packagejson",
     "build:dev": "npm run build:generate && npm run build:generate-css",
     "build:generate": "tsx ../../scripts/generator.ts",
-    "build:generate-css": "tsx --experimental-vm-modules ../../scripts/css-generator.ts",
+    "build:generate-css": "tsx ../../scripts/css-generator.ts",
     "build:update-packagejson": "tsx ../../scripts/package-json-update.ts",
     "build:code": "concurrently npm:build:code:*",
     "build:code:ts": "tsx ../../scripts/build.ts",

--- a/packages/react-components/tsconfig.build.json
+++ b/packages/react-components/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": ".",
     "module": "NodeNext",
@@ -7,6 +7,5 @@
     "noEmit": false,
     "emitDeclarationOnly": true
   },
-  "include": ["./src"],
-  "exclude": ["node_modules", "dist"]
+  "include": ["src"]
 }

--- a/packages/react-components/tsconfig.json
+++ b/packages/react-components/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["es2021", "dom"],
+  },
+  "include": ["src"]
+}

--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -14,7 +14,7 @@ type ElementData = Readonly<{
 }>;
 
 // Remove all existing files
-for await (const path of glob('**/*', { cwd: generatedDir })) {
+for await (const path of glob(resolve(generatedDir, '**/*'))) {
   await unlink(path);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,10 @@
     "declarationMap": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
-    "target": "es2021",
+    "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "lib": ["es2021", "dom"],
+    "lib": ["esnext", "dom"],
     "noEmit": true,
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
@@ -21,6 +21,6 @@
     "useUnknownInCatchVariables": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src", "scripts", "test", "dev", "types", "karma.config.cjs", "vite.config.ts"],
+  "include": ["scripts", "test", "dev", "types", "karma.config.cjs", "vite.config.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR significantly simplifies React wrapper generation; instead of TypeScript AST, it uses plain strings which improves the readability of the code. The code has been reduced by more than half as well.

Also, the generator script drops the custom `fswalk` and `fromAsync` functions in favor of the native `glob` (it is experimental but since it is our internal script I consider it ok). However, this change requires Node v22 LTS.

Since there are two packages managed by a root `tsconfig`, and `glob` needs newer TS libs, I had to switch the root to `esnext`. To keep packages on `es2021`, I created separate `tsconfig.json` files for each package. So, now, we can use `es2021` for packages and use any modern stuff in our scripts.