### PR TITLE
feat: allow adding custom data to context menu item types

### DIFF
--- a/test/typings/ContextMenu.tsx
+++ b/test/typings/ContextMenu.tsx
@@ -1,0 +1,17 @@
+import { ContextMenu, type ContextMenuItem } from '../../packages/react-components/src/ContextMenu.js';
+
+const assertType = function <TExpected>(value: TExpected) {
+  return value;
+};
+
+type CustomContextMenuItem = ContextMenuItem<{ value: string }>;
+
+const items: CustomContextMenuItem[] = [{ text: 'View', value: 'view' }];
+
+<ContextMenu
+  items={items}
+  onItemSelected={(e) => {
+    // Event item type should be inferred from items
+    assertType<CustomContextMenuItem>(e.detail.value);
+  }}
+/>;

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -230,6 +230,17 @@ const contextMenuOnItemSelected: typeof contextMenuProps.onItemSelected = (event
 };
 assertType<typeof contextMenuProps.onItemSelected>(contextMenuOnItemSelected);
 
+type CustomContextMenuItem = ContextMenuItem<{ value: string }>;
+
+const narrowedContextMenuProps = React.createElement(ContextMenu<CustomContextMenuItem>, {}).props;
+assertType<CustomContextMenuItem[] | undefined>(narrowedContextMenuProps.items);
+assertType<CustomContextMenuItem[] | undefined>(narrowedContextMenuProps.items![0].children);
+
+const narrowedContextMenuOnItemSelected: typeof narrowedContextMenuProps.onItemSelected = (event) => {
+  assertType<CustomContextMenuItem>(event.detail.value);
+};
+assertType<typeof narrowedContextMenuProps.onItemSelected>(narrowedContextMenuOnItemSelected);
+
 const menuBarProps = React.createElement(MenuBar, {}).props;
 assertType<ReactElement | string | undefined>(menuBarProps.items![0].component);
 assertType<MenuBarItem[] | undefined>(menuBarProps.items);

--- a/test/typings/api.ts
+++ b/test/typings/api.ts
@@ -259,10 +259,10 @@ const narrowedMenuBarProps = React.createElement(MenuBar<CustomMenuBarItem>, {})
 assertType<CustomMenuBarItem[] | undefined>(narrowedMenuBarProps.items);
 assertType<CustomMenuBarItem[] | undefined>(narrowedMenuBarProps.items![0].children);
 
-const narrowedContextMenuOnItemSelected: typeof narrowedMenuBarProps.onItemSelected = (event) => {
+const narrowedMenuBarOnItemSelected: typeof narrowedMenuBarProps.onItemSelected = (event) => {
   assertType<CustomMenuBarItem>(event.detail.value);
 };
-assertType<typeof narrowedMenuBarProps.onItemSelected>(narrowedContextMenuOnItemSelected);
+assertType<typeof narrowedMenuBarProps.onItemSelected>(narrowedMenuBarOnItemSelected);
 
 const popoverProps = React.createElement(Popover, {}).props;
 type PopoverProps = typeof popoverProps;


### PR DESCRIPTION
## Description

Make `ContextMenu` and `ContextMenuItem` types generic so that:
- `ContextMenuItem` accepts a type for custom item data, so that you can easily create custom item types
- `ContextMenu` accepts a custom item type, which restricts the items that can be set, and provides that type in the `item-selected` event

Part of https://github.com/vaadin/web-components/issues/8700
Depends on https://github.com/vaadin/web-components/pull/8698

## Type of change

- Feature
