### PR TITLE
fix: toggle details when nested component content changes

### DIFF
--- a/packages/react-components/src/MasterDetailLayout.tsx
+++ b/packages/react-components/src/MasterDetailLayout.tsx
@@ -100,7 +100,7 @@ function Detail({ children }: DetailProps) {
         setState('idle');
       });
     }
-  }, [state]);
+  }, [state, currentChildren]);
 
   useEffect(() => {
     if (state !== 'idle') {

--- a/test/MasterDetailLayout.spec.tsx
+++ b/test/MasterDetailLayout.spec.tsx
@@ -124,7 +124,7 @@ describe('MasterDetailLayout', () => {
     result.rerender(
       <MasterDetailLayout>
         <MasterDetailLayout.Detail>
-          <Wrapper/>
+          <Wrapper />
         </MasterDetailLayout.Detail>
       </MasterDetailLayout>,
     );
@@ -135,7 +135,9 @@ describe('MasterDetailLayout', () => {
     result.rerender(
       <MasterDetailLayout>
         <MasterDetailLayout.Detail>
-          <Wrapper><div>Wrapper content</div></Wrapper>
+          <Wrapper>
+            <div>Wrapper content</div>
+          </Wrapper>
         </MasterDetailLayout.Detail>
       </MasterDetailLayout>,
     );

--- a/test/MasterDetailLayout.spec.tsx
+++ b/test/MasterDetailLayout.spec.tsx
@@ -1,8 +1,8 @@
 import { expect, use as useChaiPlugin } from '@esm-bundle/chai';
-import { render, type RenderResult } from '@testing-library/react';
+import { render, type RenderResult, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import chaiAsPromised from 'chai-as-promised';
 import chaiDom from 'chai-dom';
-import { waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 import { MasterDetailLayout, MasterDetailLayoutElement } from '../packages/react-components/src/MasterDetailLayout.js';
 
@@ -69,7 +69,7 @@ describe('MasterDetailLayout', () => {
     expect(detail).to.have.text('Detail content');
   });
 
-  it('should toggle visibility of details area based on content', async () => {
+  it('should toggle visibility of details area when child component type changes', async () => {
     // Render without detail content
     result.rerender(
       <MasterDetailLayout>
@@ -113,6 +113,34 @@ describe('MasterDetailLayout', () => {
     );
 
     await assertDetailsHidden();
+  });
+
+  it('should toggle visibility of details area when content of the same type of child component changes', async () => {
+    function Wrapper({ children }: { children?: ReactNode }) {
+      return children;
+    }
+
+    // Render with empty wrapper
+    result.rerender(
+      <MasterDetailLayout>
+        <MasterDetailLayout.Detail>
+          <Wrapper/>
+        </MasterDetailLayout.Detail>
+      </MasterDetailLayout>,
+    );
+
+    await assertDetailsHidden();
+
+    // Render wrapper with content
+    result.rerender(
+      <MasterDetailLayout>
+        <MasterDetailLayout.Detail>
+          <Wrapper><div>Wrapper content</div></Wrapper>
+        </MasterDetailLayout.Detail>
+      </MasterDetailLayout>,
+    );
+
+    await assertDetailsVisible('Wrapper content');
   });
 
   it('should start view transition when detail component changes', async () => {


### PR DESCRIPTION
## Description

Make the details wrapper update its slot name every time the `children` reference changes, even if the type of component that's in `children` didn't change.

Note that the second issue mentioned in the ticket (component not detecting that a view transition needs to start) is not solved by this. This would either require Hilla change something in the file router, or a different approach for starting view transitions. I think I'll open a more specific issue for that afterwards.

Fixes https://github.com/vaadin/react-components/issues/313

## Type of change

- Bugfix
