### PR TITLE
refactor: validate MDL child components

### DIFF
--- a/packages/react-components/src/MasterDetailLayout.tsx
+++ b/packages/react-components/src/MasterDetailLayout.tsx
@@ -131,10 +131,7 @@ function validateChildren(children: React.ReactNode) {
   React.Children.forEach(children, (child) => {
     // Ignore non-React elements
     // We especially want to ignore text nodes to allow for whitespace resulting from formatting
-    if (!React.isValidElement(child)) {
-      return;
-    }
-    if (child.type !== Master && child.type !== Detail) {
+    if (React.isValidElement(child) && child.type !== Master && child.type !== Detail) {
       throw new Error(
         'Invalid child in MasterDetailLayout. Only <MasterDetailLayout.Master> and <MasterDetailLayout.Detail> components are allowed. Check the component docs for proper usage.',
       );

--- a/packages/react-components/src/MasterDetailLayout.tsx
+++ b/packages/react-components/src/MasterDetailLayout.tsx
@@ -26,7 +26,7 @@ function Master({ children }: MasterProps) {
  * @param nextChildren Current children
  * @returns True if the non-text children are meaningfully different, false otherwise
  */
-export function areChildrenDifferent(prevChildren: React.ReactNode, nextChildren: React.ReactNode): boolean {
+function areChildrenDifferent(prevChildren: React.ReactNode, nextChildren: React.ReactNode): boolean {
   // Convert to arrays and filter out text nodes
   const prevArray = React.Children.toArray(prevChildren).filter((child) => React.isValidElement(child));
   const nextArray = React.Children.toArray(nextChildren).filter((child) => React.isValidElement(child));
@@ -127,12 +127,57 @@ function Detail({ children }: DetailProps) {
   );
 }
 
-const MasterDetailLayout = _MasterDetailLayout as React.ComponentType<
-  React.ComponentProps<typeof _MasterDetailLayout>
-> & {
+function validateChildren(children: React.ReactNode) {
+  React.Children.forEach(children, (child) => {
+    // Ignore non-React elements
+    // We especially want to ignore text nodes to allow for whitespace resulting from formatting
+    if (!React.isValidElement(child)) {
+      return;
+    }
+    if (child.type !== Master && child.type !== Detail) {
+      throw new Error(
+        'Invalid child in MasterDetailLayout. Only <MasterDetailLayout.Master> and <MasterDetailLayout.Detail> components are allowed. Check the component docs for proper usage.',
+      );
+    }
+  });
+}
+
+const MasterDetailLayoutWithValidation: React.FC<React.ComponentProps<typeof _MasterDetailLayout>> = (props) => {
+  validateChildren(props.children);
+
+  return <_MasterDetailLayout {...props} />;
+};
+
+/**
+ * `MasterDetailLayout` is a React component for building UIs with a master
+ * (or primary) area and a detail (or secondary) area that is displayed next to, or
+ * overlaid on top of, the master area, depending on configuration and viewport size.
+ *
+ * Content for each area should be wrapped into to the respective
+ * `MasterDetailLayout.Master` and `MasterDetailLayout.Detail` wrapper components.
+ * Using any other component as a child will throw an error. To ensure that view
+ * transitions are run properly, details content should be rendered conditionally
+ * into the `MasterDetailLayout.Detail` component.
+ *
+ * @example
+ * ```tsx
+ * const selectedProduct = useSignal<Product | null>(null);
+ *
+ * <MasterDetailLayout>
+ *   <MasterDetailLayout.Master>
+ *     <ProductList onSelect={(product) => { selectedProduct.value = product }} />
+ *   </MasterDetailLayout.Master>
+ *   <MasterDetailLayout.Detail>
+ *     { selectedProduct.value && <ProductDetail product={selectedProduct.value} /> }
+ *   </MasterDetailLayout.Detail>
+ * </MasterDetailLayout>
+ * ```
+ */
+const MasterDetailLayout = MasterDetailLayoutWithValidation as typeof MasterDetailLayoutWithValidation & {
   Master: React.FC<MasterProps>;
   Detail: React.FC<DetailProps>;
 };
+
 MasterDetailLayout.Master = Master;
 MasterDetailLayout.Detail = Detail;
 

--- a/test/MasterDetailLayout.spec.tsx
+++ b/test/MasterDetailLayout.spec.tsx
@@ -35,7 +35,7 @@ describe('MasterDetailLayout', () => {
   }
 
   beforeEach(() => {
-    result = render(<MasterDetailLayout>{null}</MasterDetailLayout>);
+    result = render(<MasterDetailLayout></MasterDetailLayout>);
     startTransitionSpy = sinon.spy();
     finishTransitionSpy = sinon.spy();
 

--- a/test/MasterDetailLayout.spec.tsx
+++ b/test/MasterDetailLayout.spec.tsx
@@ -35,7 +35,7 @@ describe('MasterDetailLayout', () => {
   }
 
   beforeEach(() => {
-    result = render(<MasterDetailLayout></MasterDetailLayout>);
+    result = render(<MasterDetailLayout>{null}</MasterDetailLayout>);
     startTransitionSpy = sinon.spy();
     finishTransitionSpy = sinon.spy();
 
@@ -307,5 +307,47 @@ describe('MasterDetailLayout', () => {
     expect(startTransitionSpy.calledOnce).to.be.true;
     expect(finishTransitionSpy.calledOnce).to.be.true;
     expect(startTransitionSpy.calledBefore(finishTransitionSpy)).to.be.true;
+  });
+
+  describe('Child validation', () => {
+    it('should throw an error for invalid child component type', () => {
+      const renderWithInvalidChild = () => {
+        render(
+          <MasterDetailLayout>
+            <div>Unexpected div</div>
+            <MasterDetailLayout.Master>Master</MasterDetailLayout.Master>
+          </MasterDetailLayout>,
+        );
+      };
+      expect(renderWithInvalidChild).to.throw(
+        'Invalid child in MasterDetailLayout. Only <MasterDetailLayout.Master> and <MasterDetailLayout.Detail> components are allowed. Check the component docs for proper usage.',
+      );
+
+      const CustomComponent = () => <div>Custom</div>;
+      const renderWithInvalidCustomComponent = () => {
+        render(
+          <MasterDetailLayout>
+            <CustomComponent />
+            <MasterDetailLayout.Master>Master</MasterDetailLayout.Master>
+          </MasterDetailLayout>,
+        );
+      };
+      expect(renderWithInvalidCustomComponent).to.throw(
+        'Invalid child in MasterDetailLayout. Only <MasterDetailLayout.Master> and <MasterDetailLayout.Detail> components are allowed. Check the component docs for proper usage.',
+      );
+    });
+
+    it('should not throw an error when using null, undefined, or text nodes', () => {
+      const renderWithNull = () => {
+        render(
+          <MasterDetailLayout>
+            {null}
+            {undefined}
+            Just a text node
+          </MasterDetailLayout>,
+        );
+      };
+      expect(renderWithNull).to.not.throw();
+    });
   });
 });


### PR DESCRIPTION
## Description

Make MDL verify its child components so that only `MasterDetailLayout.Master` and `MasterDetailLayout.Detail` are valid child components. Text nodes are still considered valid in order to allow for whitespace from formatting. It seems otherwise unlikely that people would try to slot text into individual areas.

Also adds JSDoc for `MasterDetailLayout` to explain how the component should be used.

Fixes https://github.com/vaadin/react-components/issues/317

## Type of change

- Refactor