### PR TITLE
chore: add missing node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/chai-as-promised": "^8.0.1",
         "@types/chai-dom": "^1.11.3",
+        "@types/node": "^22.15.17",
         "@types/react": "18.3.18",
         "@types/react-dom": "^18.3.3",
         "@types/sinon": "^17.0.3",
@@ -1332,6 +1333,16 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
       "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -5323,6 +5334,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -6753,6 +6771,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
       "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/prop-types": {
       "version": "15.7.14",
@@ -9956,6 +9983,12 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/chai-as-promised": "^8.0.1",
     "@types/chai-dom": "^1.11.3",
+    "@types/node": "^22.15.17",
     "@types/react": "18.3.18",
     "@types/react-dom": "^18.3.3",
     "@types/sinon": "^17.0.3",


### PR DESCRIPTION
## Description

Builds on main fail with TS compilation errors due to missing Node.js types: https://github.com/vaadin/react-components/actions/runs/14908506578/job/41877160875. Maybe some transitive dependency is missing due to https://github.com/vaadin/react-components/pull/321 or some change in the latest WC alpha. Let's try adding them explicitly.

## Type of change

- Internal