### PR TITLE
chore: remove generator workaround

### DIFF
--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -63,11 +63,6 @@ async function prepareElementFiles(
 
       const path = await search(element.name, resolve(nodeModulesDir, packageName));
 
-      // Temporarily remove vaadin-date-picker-light and vaadin-combo-box-light until WC dependencies do not include them anymore
-      if (element.name === 'vaadin-date-picker-light' || element.name === 'vaadin-combo-box-light') {
-        return;
-      }
-
       if (path && dependencies.includes(packageName)) {
         elementFilesMap.set(element, {
           packageName,


### PR DESCRIPTION
## Description

Drop the workaround added in https://github.com/vaadin/react-components/pull/334, now that `DatePickerLight` and `ComboBoxLight` are not included in the web components anymore.

## Type of change

- Internal