### PR TITLE
chore: pin TypeScript version to ~5.8.3 for now

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "sinon": "^19.0.2",
         "tsx": "^4.19.2",
         "type-fest": "4.30.1",
-        "typescript": "^5.7.2",
+        "typescript": "~5.8.3",
         "vite": "^5.4.11",
         "vitest": "^3.1.3",
         "vitest-browser-react": "^0.1.1"
@@ -5078,6 +5078,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sinon": "^19.0.2",
     "tsx": "^4.19.2",
     "type-fest": "4.30.1",
-    "typescript": "^5.7.2",
+    "typescript": "~5.8.3",
     "vite": "^5.4.11",
     "vitest": "^3.1.3",
     "vitest-browser-react": "^0.1.1"


### PR DESCRIPTION
## Description

There are following errors with TypeScript 5.9.2:

```
[dts] src/generated/EmailField.ts(15,49): error TS2344: Type 'EmailField' does not satisfy the constraint 'HTMLElement'.
[dts]   Type 'EmailField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/EmailField.ts(17,5): error TS2322: Type 'typeof EmailField' is not assignable to type 'Constructor<HTMLElement> | PolymerConstructor<HTMLElement>'.
[dts]   Type 'typeof EmailField' is not assignable to type 'Constructor<HTMLElement>'.
[dts]     Type 'EmailField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/IntegerField.ts(15,51): error TS2344: Type 'IntegerField' does not satisfy the constraint 'HTMLElement'.
[dts]   Type 'IntegerField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/IntegerField.ts(17,5): error TS2322: Type 'typeof IntegerField' is not assignable to type 'Constructor<HTMLElement> | PolymerConstructor<HTMLElement>'.
[dts]   Type 'typeof IntegerField' is not assignable to type 'Constructor<HTMLElement>'.
[dts]     Type 'IntegerField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/NumberField.ts(15,50): error TS2344: Type 'NumberField' does not satisfy the constraint 'HTMLElement'.
[dts]   Type 'NumberField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/NumberField.ts(17,5): error TS2322: Type 'typeof NumberField' is not assignable to type 'Constructor<HTMLElement> | PolymerConstructor<HTMLElement>'.
[dts]   Type 'typeof NumberField' is not assignable to type 'Constructor<HTMLElement>'.
[dts]     Type 'NumberField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/TextArea.ts(15,47): error TS2344: Type 'TextArea' does not satisfy the constraint 'HTMLElement'.
[dts]   Type 'TextArea' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/TextArea.ts(17,5): error TS2322: Type 'typeof TextArea' is not assignable to type 'Constructor<HTMLElement> | PolymerConstructor<HTMLElement>'.
[dts]   Type 'typeof TextArea' is not assignable to type 'Constructor<HTMLElement>'.
[dts]     Type 'TextArea' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/TextField.ts(15,48): error TS2344: Type 'TextField' does not satisfy the constraint 'HTMLElement'.
[dts]   Type 'TextField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
[dts] src/generated/TextField.ts(17,5): error TS2322: Type 'typeof TextField' is not assignable to type 'Constructor<HTMLElement> | PolymerConstructor<HTMLElement>'.
[dts]   Type 'typeof TextField' is not assignable to type 'Constructor<HTMLElement>'.
[dts]     Type 'TextField' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, autocorrect, and 312 more.
```

## Type of change

- Internal change