### PR TITLE
test: adjust components tests to overlay changes

### DIFF
--- a/test/ComboBox.spec.tsx
+++ b/test/ComboBox.spec.tsx
@@ -1,16 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { ComboBox, type ComboBoxElement } from '../packages/react-components/src/ComboBox.js';
-import createOverlayCloseCatcher from './utils/createOverlayCloseCatcher.js';
+import { ComboBox } from '../packages/react-components/src/ComboBox.js';
 import sinon from 'sinon';
 
 describe('ComboBox', () => {
-  const overlayTag = 'vaadin-combo-box-overlay';
-
-  const [ref, catcher] = createOverlayCloseCatcher<ComboBoxElement>(overlayTag, (ref) => ref.close());
-
-  afterEach(catcher);
-
   it('should render correctly', () => {
     type Item = Readonly<{ value: string; index: number }>;
 
@@ -23,7 +16,6 @@ describe('ComboBox', () => {
 
     const { container } = render(
       <ComboBox<Item>
-        ref={ref}
         items={items}
         opened
         itemLabelPath="value"
@@ -35,10 +27,7 @@ describe('ComboBox', () => {
     const comboBox = container.querySelector('vaadin-combo-box');
     expect(comboBox).to.exist;
 
-    const comboBoxOverlay = document.body.querySelector(overlayTag);
-    expect(comboBoxOverlay).to.exist;
-
-    const bar = comboBoxOverlay!.querySelector('vaadin-combo-box-item:nth-child(2)');
+    const bar = comboBox!.querySelector('vaadin-combo-box-item:nth-child(2)');
     expect(bar).to.exist;
 
     bar!.dispatchEvent(new PointerEvent('click', { bubbles: true }));

--- a/test/Dialog.spec.tsx
+++ b/test/Dialog.spec.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
 import sinon from 'sinon';
 import { Dialog } from '../packages/react-components/src/Dialog.js';
@@ -6,14 +6,10 @@ import { nextRender } from './utils/nextRender.js';
 import { useState } from 'react';
 
 describe('Dialog', () => {
-  const overlayTag = 'vaadin-dialog-overlay';
-
-  afterEach(() => {
-    document.querySelector('vaadin-dialog-overlay')?.remove();
-  });
+  const dialogTag = 'vaadin-dialog';
 
   function assert() {
-    const dialog = document.querySelector(overlayTag);
+    const dialog = document.querySelector(dialogTag);
     expect(dialog).to.exist;
 
     const childNodes = Array.from(dialog!.childNodes);

--- a/test/MenuBar.spec.tsx
+++ b/test/MenuBar.spec.tsx
@@ -3,7 +3,7 @@ import { render } from 'vitest-browser-react';
 import { MenuBar, MenuBarElement } from '../packages/react-components/src/MenuBar.js';
 import sinon from 'sinon';
 
-const overlayTag = 'vaadin-menu-bar-overlay';
+const subMenuTag = 'vaadin-menu-bar-submenu';
 const menuItemTag = 'vaadin-menu-bar-item';
 const menuButtonTag = 'vaadin-menu-bar-button';
 
@@ -13,16 +13,21 @@ async function until(predicate: () => boolean) {
   }
 }
 
-async function menuAnimationComplete() {
-  await new Promise((r) => requestAnimationFrame(r));
-  await until(
-    () => !document.querySelector(`${overlayTag}[opening]`) && !!document.querySelector(`${overlayTag}[opened]`),
-  );
+async function overlayOpened(): Promise<void> {
+  return new Promise((resolve) => {
+    document.addEventListener(
+      'vaadin-overlay-open',
+      () => {
+        resolve();
+      },
+      { once: true },
+    );
+  });
 }
 
 async function openRootItemSubMenu(rootMenuItem: EventTarget) {
   rootMenuItem.dispatchEvent(new PointerEvent('click', { bubbles: true }));
-  await menuAnimationComplete();
+  await overlayOpened();
 }
 
 describe('MenuBar', () => {
@@ -58,7 +63,7 @@ describe('MenuBar', () => {
     const rootItem = menuBar.querySelector(menuButtonTag)!;
     await openRootItemSubMenu(rootItem);
 
-    const item = document.querySelector(`${overlayTag} ${menuItemTag} > span`);
+    const item = document.querySelector(`${subMenuTag} ${menuItemTag} > span`);
     expect(item).to.have.text('foo');
   });
 

--- a/test/MultiSelectComboBox.spec.tsx
+++ b/test/MultiSelectComboBox.spec.tsx
@@ -1,21 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
-import {
-  MultiSelectComboBox,
-  type MultiSelectComboBoxElement,
-} from '../packages/react-components/src/MultiSelectComboBox.js';
-import createOverlayCloseCatcher from './utils/createOverlayCloseCatcher.js';
+import { MultiSelectComboBox } from '../packages/react-components/src/MultiSelectComboBox.js';
 import sinon from 'sinon';
 
 describe('MultiSelectComboBox', () => {
   const overlayTag = 'vaadin-multi-select-combo-box-overlay';
-
-  const [ref, catcher] = createOverlayCloseCatcher<MultiSelectComboBoxElement>(
-    overlayTag,
-    (ref) => (ref.opened = false),
-  );
-
-  afterEach(catcher);
 
   it('should render correctly', () => {
     type Item = Readonly<{ value: string; index: number }>;
@@ -29,7 +18,6 @@ describe('MultiSelectComboBox', () => {
 
     const { container } = render(
       <MultiSelectComboBox<Item>
-        ref={ref}
         items={items}
         opened
         renderer={({ item }) => <>{item.value}</>}
@@ -40,10 +28,7 @@ describe('MultiSelectComboBox', () => {
     const comboBox = container.querySelector('vaadin-multi-select-combo-box');
     expect(comboBox).to.exist;
 
-    const comboBoxOverlay = document.body.querySelector(overlayTag);
-    expect(comboBoxOverlay).to.exist;
-
-    const bar = comboBoxOverlay!.querySelector('vaadin-multi-select-combo-box-item:nth-child(2)');
+    const bar = comboBox!.querySelector('vaadin-multi-select-combo-box-item:nth-child(2)');
     expect(bar).to.exist;
 
     bar!.dispatchEvent(new PointerEvent('click', { bubbles: true }));


### PR DESCRIPTION
## Description

Updated tests for components to not expect overlays to be placed in the body.
Also removed the overlay close catcher since overlays are no longer teleported. 

## Type of change

- Test