### PR TITLE
refactor: deprecate renderers in Popover

### DIFF
--- a/packages/react-components/src/Popover.tsx
+++ b/packages/react-components/src/Popover.tsx
@@ -9,6 +9,7 @@ import {
 import { Popover as _Popover, type PopoverElement, type PopoverProps as _PopoverProps } from './generated/Popover.js';
 import { useSimpleOrChildrenRenderer } from './renderers/useSimpleOrChildrenRenderer.js';
 import type { ReactSimpleRendererProps } from './renderers/useSimpleRenderer.js';
+import { issueWarning } from './utils/warnings';
 
 export * from './generated/Popover.js';
 
@@ -22,10 +23,22 @@ type OmittedPopoverHTMLAttributes = Omit<
 export type PopoverProps = Partial<Omit<_PopoverProps, 'children' | 'renderer' | keyof OmittedPopoverHTMLAttributes>> &
   Readonly<{
     children?: ReactNode | ComponentType<PopoverReactRendererProps>;
+    /**
+     * @deprecated Pass children directly to the popover instead
+     */
     renderer?: ComponentType<PopoverReactRendererProps> | null;
   }>;
 
 function Popover({ children, ...props }: PopoverProps, ref: ForwardedRef<PopoverElement>): ReactElement | null {
+  if (props.renderer) {
+    issueWarning('<Popover>: Using the renderer prop is deprecated. Pass children directly to the component instead.');
+  }
+  if (typeof children === 'function') {
+    issueWarning(
+      '<Popover>: Passing a component type as children is deprecated. Pass children directly to the component instead.',
+    );
+  }
+
   const [portals, renderer] = useSimpleOrChildrenRenderer(props.renderer, children);
 
   return (

--- a/packages/react-components/src/utils/warnings.ts
+++ b/packages/react-components/src/utils/warnings.ts
@@ -1,0 +1,10 @@
+const issuedWarnings = new Set();
+
+export function issueWarning(warning: string) {
+  if (issuedWarnings.has(warning)) {
+    return;
+  }
+
+  issuedWarnings.add(warning);
+  console.warn(warning);
+}


### PR DESCRIPTION
## Description

Deprecate the `renderer` prop and passing a component function as `children` in `Popover`, in favor of just passing children directly.

Fixes https://github.com/vaadin/react-components/issues/348
