### PR TITLE
refactor!: remove TabSheet tab helper in v25

### DIFF
--- a/dev/kitchen-sink/Row10.tsx
+++ b/dev/kitchen-sink/Row10.tsx
@@ -1,7 +1,5 @@
 import { BoardRow } from '../../packages/react-components-pro/src/BoardRow.js';
-import { Tab } from '../../packages/react-components/src/Tab.js';
-import { Tabs } from '../../packages/react-components/src/Tabs.js';
-import { tab, TabSheet } from '../../packages/react-components/src/TabSheet.js';
+import { TabSheet, TabSheetTab } from '../../packages/react-components/src/TabSheet.js';
 
 export default function Row10() {
   return (
@@ -10,17 +8,17 @@ export default function Row10() {
         <div slot="prefix">Prefix</div>
         <div slot="suffix">Suffix</div>
 
-        <Tabs slot="tabs">
-          <Tab id="tab-1">Tab 1</Tab>
-          <Tab id="tab-2">Tab 2</Tab>
-          <Tab id="tab-3">Tab 3</Tab>
-        </Tabs>
+        <TabSheetTab label="Tab 1">
+          <div>Panel 1</div>
+        </TabSheetTab>
 
-        <div {...tab('tab-1')}>Panel 1</div>
-        {/* @ts-expect-error TS2322: "tab" is not an HTML standard attribute */}
-        <div tab="tab-2">Panel 2</div>
-        {/* @ts-expect-error TS2322: "tab" is not an HTML standard attribute */}
-        <div tab="tab-3">Panel 3</div>
+        <TabSheetTab label="Tab 2">
+          <div>Panel 2</div>
+        </TabSheetTab>
+
+        <TabSheetTab label="Tab 3">
+          <div>Panel 3</div>
+        </TabSheetTab>
       </TabSheet>
     </BoardRow>
   );

--- a/dev/kitchen-sink/index.html
+++ b/dev/kitchen-sink/index.html
@@ -5,6 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Kitchen Sink App</title>
+    <script type="module">
+      import '@vaadin/vaadin-lumo-styles/lumo.css';
+    </script>
     <script type="module" src="index.ts" async></script>
   </head>
   <body>

--- a/packages/react-components/src/TabSheet.tsx
+++ b/packages/react-components/src/TabSheet.tsx
@@ -99,30 +99,3 @@ function TabSheet(props: TabSheetProps, ref: ForwardedRef<TabSheetElement>) {
 const ForwardedTabSheet = forwardRef(TabSheet);
 
 export { ForwardedTabSheet as TabSheet };
-
-/**
- * A helper function that allows declaring the tab identifier on the children
- * of the `<TabSheet/>` component
- *
- * ### Usage
- *
- * ```tsx
- * <TabSheet>
- *   <Tabs slot="tabs">
- *     <Tab id="about">About</Tab>
- *     <Tab id="contuct">Contact us</Tab>
- *   </Tabs>
- *   <div {...tab('about')}>This tab is all about,..</div>
- *   <div {...tab('contact')}>Our website: ...</div>
- * </TabSheet>
- * ```
- *
- * @param tab The identifier of the correspoding tab.
- *
- * @returns object with HTML attribute values recognized on tab sheet children.
- * @deprecated Use `<TabSheetTab/>` instead.
- */
-export function tab(tab: string): Record<string, string> {
-  console.warn('Using the `tab` helper function is deprecated. Use <TabSheetTab/> instead.');
-  return { tab } as Record<string, string>;
-}

--- a/test/TabSheet.spec.tsx
+++ b/test/TabSheet.spec.tsx
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { TabSheet, TabSheetTab, tab } from '../packages/react-components/src/TabSheet.js';
+import { TabSheet, TabSheetTab } from '../packages/react-components/src/TabSheet.js';
 import type { TabElement } from '../packages/react-components/src/Tab.js';
-import sinon from 'sinon';
 import { useState } from 'react';
 
 function getTabSheet() {
@@ -141,13 +140,6 @@ describe('TabSheet', () => {
 
     const suffix = getTabSheet().querySelector('[slot="suffix"]');
     expect(suffix).to.have.text('SUFFIX');
-  });
-
-  it('should warn when using the tab helper', async () => {
-    const stub = sinon.stub(console, 'warn');
-    tab('Tab 1');
-    expect(stub.calledOnce).to.be.true;
-    stub.restore();
   });
 
   it('should expand content element to full size', async () => {


### PR DESCRIPTION
## Description

Remove the deprecated `tab` helper function.

## Type of change

- Breaking change