### PR TITLE
refactor: expose ARIA attributes in overlay components

### DIFF
--- a/packages/react-components/src/ConfirmDialog.ts
+++ b/packages/react-components/src/ConfirmDialog.ts
@@ -9,7 +9,7 @@ export * from './generated/ConfirmDialog.js';
 
 type OmittedConfirmDialogHTMLAttributes = Omit<
   HTMLAttributes<ConfirmDialogElement>,
-  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'aria-label'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'children' | 'aria-label' | 'aria-labelledby'
 >;
 
 export type ConfirmDialogProps = Partial<Omit<_ConfirmDialogProps, keyof OmittedConfirmDialogHTMLAttributes>>;

--- a/packages/react-components/src/Dialog.tsx
+++ b/packages/react-components/src/Dialog.tsx
@@ -16,7 +16,7 @@ export type DialogReactRendererProps = ReactSimpleRendererProps<DialogElement>;
 
 type OmittedDialogHTMLAttributes = Omit<
   HTMLAttributes<DialogElement>,
-  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'aria-label' | 'draggable'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'role' | 'aria-label' | 'aria-labelledby' | 'draggable'
 >;
 
 export type DialogProps = Partial<

--- a/packages/react-components/src/Popover.tsx
+++ b/packages/react-components/src/Popover.tsx
@@ -17,7 +17,7 @@ export type PopoverReactRendererProps = ReactSimpleRendererProps<PopoverElement>
 
 type OmittedPopoverHTMLAttributes = Omit<
   HTMLAttributes<PopoverElement>,
-  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot'
+  'id' | 'className' | 'dangerouslySetInnerHTML' | 'slot' | 'role' | 'aria-label' | 'aria-labelledby'
 >;
 
 export type PopoverProps = Partial<Omit<_PopoverProps, 'children' | 'renderer' | keyof OmittedPopoverHTMLAttributes>> &


### PR DESCRIPTION
## Description

Allow passing `role`, `aria-label`, `aria-labelledby` to overlay components so that these can be used instead of deprecated custom properties. `role` is still excluded from `ConfirmDialog` as it should use `alertdialog`.

## Type of change

- Refactor