### PR TITLE
refactor: deprecate CookieConsent

### DIFF
--- a/packages/react-components-pro/src/CookieConsent.ts
+++ b/packages/react-components-pro/src/CookieConsent.ts
@@ -24,6 +24,9 @@ type OmittedCookieConsentHTMLAttributes = Omit<
 
 export type CookieConsentProps = Partial<Omit<_CookieConsentProps, keyof OmittedCookieConsentHTMLAttributes>>;
 
+/**
+ * @deprecated CookieConsent is deprecated and will be removed without a replacement in Vaadin 25.
+ */
 export const CookieConsent = _CookieConsent as (
   props: CookieConsentProps & RefAttributes<CookieConsentElement>,
 ) => ReactElement | null;


### PR DESCRIPTION
## Description

Deprecate `CookieConsent` with the intention to remove it in Vaadin 25.

Part of https://github.com/vaadin/web-components/issues/9791

## Type of change

- Refactor