### PR TITLE
chore: remove Lumo import from the kitchen sink

### DIFF
--- a/dev/kitchen-sink/App.tsx
+++ b/dev/kitchen-sink/App.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import '../../packages/react-components/css/lumo/Typography.css';
 import { AppLayout } from '../../packages/react-components/src/AppLayout.js';
 import { Avatar } from '../../packages/react-components/src/Avatar.js';
 import { Board } from '../../packages/react-components-pro/src/Board.js';


### PR DESCRIPTION
## Description

Related to https://github.com/vaadin/web-components/pull/10138

Lumo is already included to the kitchen sink page since https://github.com/vaadin/react-components/pull/350

## Type of change

- Internal change