### PR TITLE
refactor!: exclude internal grid-pro events from generator

### DIFF
--- a/scripts/utils/settings.ts
+++ b/scripts/utils/settings.ts
@@ -44,9 +44,12 @@ export const eventSettings = new Map<string, EventSettings>([
   ['Grid', { makeUnknown: ['size-changed', 'data-provider-changed'] }],
   [
     'GridPro',
-    { makeUnknown: ['size-changed', 'data-provider-changed', 'enter-next-row-changed', 'single-cell-edit-changed'] },
+    {
+      remove: ['enter-next-row-changed', 'single-cell-edit-changed'],
+      makeUnknown: ['size-changed', 'data-provider-changed'],
+    },
   ],
-  ['GridProEditColumn', { makeUnknown: ['editor-type-changed'] }],
+  ['GridProEditColumn', { remove: ['editor-type-changed'] }],
   [
     'MultiSelectComboBox',
     {


### PR DESCRIPTION
## Summary

- Drop `enter-next-row-changed` and `single-cell-edit-changed` from `<GridPro>` and `editor-type-changed` from `<GridProEditColumn>` in the generator's event map.
- Previously these were emitted as `CustomEvent<unknown>` via `makeUnknown`, because their notifying props live on `InlineEditingMixin` / `GridProEditColumnMixin` and the element's TS `EventMap` doesn't declare them. They back internal state sync and aren't meant for public consumption, so the weakly-typed props were more trap than feature.
- Surfaced while testing React wrapper generation against the CEM-based `web-types.json` on `vaadin/web-components#11539` — CEM correctly omits these events (no `@fires`), and this change codifies "omit them" as the intended behaviour on the React side.

## Test plan

- [ ] `npm run build` succeeds.
- [ ] `npm run validate:types` passes.
- [ ] `grep -rn "onEnterNextRowChanged\|onSingleCellEditChanged\|onEditorTypeChanged" packages/ dev/ test/` returns nothing (no consumer relied on these props).
- [ ] Inline editing on `<GridPro>` still works in the dev page (`/dev/grid-pro`) — editing, committing, and cancelling cells.

## BREAKING CHANGE

`onEnterNextRowChanged` and `onSingleCellEditChanged` are removed from `<GridPro>`. `onEditorTypeChanged` is removed from `<GridProEditColumn>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)