### PR TITLE
chore: remove onInput handler from DatePicker dev page

### DIFF
--- a/dev/pages/DatePicker.tsx
+++ b/dev/pages/DatePicker.tsx
@@ -64,10 +64,6 @@ export default function DatePickerPage() {
             const target = e.target as HTMLInputElement;
             logEvent(`change: ${target.value}`);
           }}
-          onInput={(e: Event) => {
-            const target = e.target as HTMLInputElement;
-            logEvent(`input: ${target.value}`);
-          }}
           min={minDate}
           max={maxDate}
           initialPosition={initialPos}


### PR DESCRIPTION
## Summary

- The `onInput` handler in `dev/pages/DatePicker.tsx` only logged input events for debugging — `onChange` and `onValueChanged` already cover the user-visible state transitions on the dev page.
- Drops the prop ahead of the CEM-based web-types migration in `vaadin/web-components#11539`, which intentionally excludes `vaadin-date-picker.input` (forwarded native event, not part of the public component API).

## Test plan

- [ ] `npm run validate:types` passes.
- [ ] `npm run dev` — open `/dev/datepicker`, type / pick a value: the event log still shows `value-changed`, `change`, and `validated` lines (no `input:` line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)