### PR TITLE
chore: upgrade TypeScript to version 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "sinon": "^19.0.2",
         "tsx": "^4.19.2",
         "type-fest": "4.30.1",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "vite": "^8.0.3",
         "vitest": "^4.1.2",
         "vitest-browser-react": "^2.1.0"
@@ -5280,9 +5280,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "sinon": "^19.0.2",
     "tsx": "^4.19.2",
     "type-fest": "4.30.1",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "vite": "^8.0.3",
     "vitest": "^4.1.2",
     "vitest-browser-react": "^2.1.0"

--- a/packages/react-components-pro/tsconfig.build.json
+++ b/packages/react-components-pro/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": ".",
+    "rootDir": "./src",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": false,

--- a/packages/react-components/tsconfig.build.json
+++ b/packages/react-components/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": ".",
+    "rootDir": "./src",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": false,

--- a/types/css.d.ts
+++ b/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';


### PR DESCRIPTION
## Summary
- Bump `typescript` devDependency from `^5.7.2` to `^6.0.3`.
- Add explicit `rootDir: "./src"` to both packages' `tsconfig.build.json` — TS 6 no longer infers it from the common source directory when emitting (`TS5011`).
- Add ambient `*.css` module declaration in `types/css.d.ts` for the side-effect CSS imports in `dev/pages/Dashboard.tsx`, `DashboardLayout.tsx`, and `MasterDetailLayout.tsx` — TS 6 enforces type declarations for side-effect imports (`TS2882`).

## Test plan
- [ ] `npm run validate` passes (types, prettier, build)
- [ ] `npm run build` produces clean dts output for both packages with no stray files in `src/`
- [ ] `npm run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)