### PR TITLE
refactor: exclude internal grid-filter event from generator

### DIFF
--- a/scripts/utils/settings.ts
+++ b/scripts/utils/settings.ts
@@ -42,6 +42,7 @@ export const eventSettings = new Map<string, EventSettings>([
   ['ComboBoxLight', { remove: ['vaadin-combo-box-dropdown-closed', 'vaadin-combo-box-dropdown-opened'] }],
   ['CrudEdit', { makeUnknown: ['edit'] }],
   ['Grid', { makeUnknown: ['size-changed', 'data-provider-changed'] }],
+  ['GridFilter', { remove: ['filter-changed'] }],
   [
     'GridPro',
     {


### PR DESCRIPTION
## Summary

- Drop `filter-changed` on `<GridFilter>` (`vaadin-grid-filter`) from the generated React wrapper. The event is internal — `vaadin-grid-filter-column` listens for it to update the parent grid's filters — and not part of the public component API.
- `@vaadin/grid 25.2.0-alpha10` ships CEM-based web-types that surface `filter-changed` via `@fires`, but the TS class's `GridFilterEventMap` doesn't declare it. Once consumed in this repo, `tsc -p packages/react-components/tsconfig.build.json` (run via `build:code:dts`) fails with:

  ```
  packages/react-components/src/generated/GridFilter.ts(8,52):
    error TS2339: Property 'filter-changed' does not exist on type 'GridFilterEventMap'.
  ```

- Excluding the event in `scripts/utils/settings.ts` mirrors the existing handling of `crud-edit.edit`, `app-layout.close-overlay-drawer`, and the GridPro internal events from #377. The entry can be removed once the upstream `@fires` annotation is dropped or `filter-changed` is added to `GridFilterEventMap`.

## Test plan

- [ ] After bumping `@vaadin/* @25.2.0-alpha10` (or any version that includes the CEM web-types) and running `npm install`, `npm run build` succeeds without the `TS2339 'filter-changed'` error.
- [ ] `npm run validate:types` passes.
- [ ] `grep -r onFilterChanged packages/ dev/ test/` returns no consumer code referencing the removed prop on `<GridFilter>` (the prop on `<GridSorter>` / `<GridFilterColumn>` is unrelated and stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)