### PR TITLE
refactor: clean up obsolete event settings

### DIFF
--- a/scripts/utils/settings.ts
+++ b/scripts/utils/settings.ts
@@ -15,7 +15,6 @@ export type GenericElementInfo = Readonly<{
 
 export const genericElements = new Map<string, GenericElementInfo>([
   ['ComboBox', { numberOfGenerics: 1 }],
-  ['ComboBoxLight', { numberOfGenerics: 1 }],
   ['Crud', { numberOfGenerics: 1 }],
   ['Dashboard', { numberOfGenerics: 1, typeConstraints: ['DashboardItem'] }],
   ['Grid', { numberOfGenerics: 1 }],
@@ -36,28 +35,10 @@ export type EventSettings = Readonly<{
 }>;
 
 export const eventSettings = new Map<string, EventSettings>([
-  ['AppLayout', { remove: ['close-overlay-drawer'] }],
-  ['Checkbox', { remove: ['value-changed'] }],
   ['ComboBox', { remove: ['vaadin-combo-box-dropdown-closed', 'vaadin-combo-box-dropdown-opened'] }],
-  ['ComboBoxLight', { remove: ['vaadin-combo-box-dropdown-closed', 'vaadin-combo-box-dropdown-opened'] }],
-  ['CrudEdit', { makeUnknown: ['edit'] }],
   ['Grid', { makeUnknown: ['size-changed', 'data-provider-changed'] }],
   ['GridFilter', { remove: ['filter-changed'] }],
-  [
-    'GridPro',
-    {
-      remove: ['enter-next-row-changed', 'single-cell-edit-changed'],
-      makeUnknown: ['size-changed', 'data-provider-changed'],
-    },
-  ],
-  ['GridProEditColumn', { remove: ['editor-type-changed'] }],
-  [
-    'MultiSelectComboBox',
-    {
-      remove: ['vaadin-combo-box-dropdown-closed', 'vaadin-combo-box-dropdown-opened'],
-    },
-  ],
-  ['RadioButton', { remove: ['value-changed'] }],
+  ['GridPro', { makeUnknown: ['size-changed', 'data-provider-changed'] }],
 ]);
 
 export const elementsWithMissingEntrypoint = new Set<string>([]);


### PR DESCRIPTION
## Summary

Drop entries in `scripts/utils/settings.ts` that no longer match anything in the `@vaadin/* @25.2.0-alpha10` web-types and would silently no-op:

| Removed | Why obsolete in alpha10 |
| --- | --- |
| `genericElements: ComboBoxLight` | Element removed entirely in V25 |
| `AppLayout.remove: ['close-overlay-drawer']` | Event filtered upstream (CEM) — no longer in `app-layout/web-types.json` |
| `Checkbox.remove: ['value-changed']` | Event filtered upstream — no longer in `checkbox/web-types.json` |
| `ComboBoxLight.remove: […]` | Element gone (see above) |
| `CrudEdit.makeUnknown: ['edit']` | `vaadin-crud-edit` ships zero events now |
| `GridPro.remove: ['enter-next-row-changed', 'single-cell-edit-changed']` | Both events absent from `grid-pro/web-types.json` (alpha10 aligned with #377) |
| `GridProEditColumn.remove: ['editor-type-changed']` | Entire entry — `vaadin-grid-pro-edit-column` ships zero events |
| `MultiSelectComboBox.remove: […]` | Component no longer inherits the dropdown events |
| `RadioButton.remove: ['value-changed']` | `vaadin-radio-button` never declared `@fires value-changed`; the event lives on `vaadin-radio-group` only |

### Kept (still needed against alpha10)

- `ComboBox.remove: ['vaadin-combo-box-dropdown-closed', '…-opened']` — both events still on `vaadin-combo-box`
- `Grid.makeUnknown: ['size-changed', 'data-provider-changed']` — both events still emitted
- `GridFilter.remove: ['filter-changed']` — alpha10 leak addressed in #381
- `GridPro.makeUnknown: ['size-changed', 'data-provider-changed']` — both events still emitted

## Test plan

- [ ] `npm run build` succeeds (covers `build:generate` for both packages and `tsc -p tsconfig.build.json` via `build:code:dts`).
- [ ] `npm run validate:types` passes.
- [ ] `npm run validate:build` passes.
- [ ] Spot-check generated wrappers:
  - `packages/react-components/src/generated/ComboBoxLight.ts` does not exist.
  - `<AppLayout>` has no `onCloseOverlayDrawer`; `<Checkbox>` has no `onValueChanged`.
  - `<CrudEdit>`, `<GridProEditColumn>` show `const events = {}`.
  - `<GridPro>` has no `onEnterNextRowChanged` / `onSingleCellEditChanged`.
  - `<MultiSelectComboBox>` has no `onVaadinComboBoxDropdownOpened` / `onVaadinComboBoxDropdownClosed`.
  - `<RadioButton>` shows `const events = { onCheckedChanged: "checked-changed" }` (no `onValueChanged`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)