### PR TITLE
feat: add Breadcrumbs and BreadcrumbsItem components (#383) (CP: 25.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,6 +1273,20 @@
         "lit": "^3.0.0"
       }
     },
+    "node_modules/@vaadin/breadcrumbs": {
+      "version": "25.2.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/breadcrumbs/-/breadcrumbs-25.2.2.tgz",
+      "integrity": "sha512-xTxJbrHyUBoOAIWwdUjWtRtrqJikBjYu3575s7JTa1BU0AmxI42TjCVguPnK/jeId/596nN7iSKaV1QA3HW3Rw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^1.3.0",
+        "@vaadin/a11y-base": "~25.2.2",
+        "@vaadin/component-base": "~25.2.2",
+        "@vaadin/overlay": "~25.2.2",
+        "@vaadin/vaadin-themable-mixin": "~25.2.2",
+        "lit": "^3.0.0"
+      }
+    },
     "node_modules/@vaadin/button": {
       "version": "25.2.2",
       "resolved": "https://registry.npmjs.org/@vaadin/button/-/button-25.2.2.tgz",
@@ -6300,6 +6314,7 @@
         "@vaadin/avatar": "25.2.2",
         "@vaadin/avatar-group": "25.2.2",
         "@vaadin/badge": "25.2.2",
+        "@vaadin/breadcrumbs": "25.2.2",
         "@vaadin/button": "25.2.2",
         "@vaadin/card": "25.2.2",
         "@vaadin/checkbox": "25.2.2",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -33,6 +33,7 @@
     "@vaadin/avatar": "25.2.2",
     "@vaadin/avatar-group": "25.2.2",
     "@vaadin/badge": "25.2.2",
+    "@vaadin/breadcrumbs": "25.2.2",
     "@vaadin/button": "25.2.2",
     "@vaadin/card": "25.2.2",
     "@vaadin/checkbox": "25.2.2",
@@ -150,6 +151,14 @@
     "./Badge.js": {
       "types": "./Badge.d.ts",
       "default": "./Badge.js"
+    },
+    "./Breadcrumbs.js": {
+      "types": "./Breadcrumbs.d.ts",
+      "default": "./Breadcrumbs.js"
+    },
+    "./BreadcrumbsItem.js": {
+      "types": "./BreadcrumbsItem.d.ts",
+      "default": "./BreadcrumbsItem.js"
     },
     "./Button.js": {
       "types": "./Button.d.ts",
@@ -438,6 +447,8 @@
     "./Avatar": "./Avatar.js",
     "./AvatarGroup": "./AvatarGroup.js",
     "./Badge": "./Badge.js",
+    "./Breadcrumbs": "./Breadcrumbs.js",
+    "./BreadcrumbsItem": "./BreadcrumbsItem.js",
     "./Button": "./Button.js",
     "./Card": "./Card.js",
     "./Checkbox": "./Checkbox.js",

--- a/packages/react-components/src/Breadcrumbs.ts
+++ b/packages/react-components/src/Breadcrumbs.ts
@@ -1,0 +1,1 @@
+export * from './generated/Breadcrumbs.js';

--- a/packages/react-components/src/BreadcrumbsItem.ts
+++ b/packages/react-components/src/BreadcrumbsItem.ts
@@ -1,0 +1,1 @@
+export * from './generated/BreadcrumbsItem.js';


### PR DESCRIPTION
## Description

We missed to backport Breadcrumbs to 25.2 due to the fact that WC was branched out after 25.2 release.

## Type of change

- Cherry-pick