### PR TITLE
feat: add SelectItem and SelectListBox components

### DIFF
--- a/dev/kitchen-sink/Row8.tsx
+++ b/dev/kitchen-sink/Row8.tsx
@@ -1,18 +1,19 @@
 import { BoardRow } from '../../packages/react-components-pro/src/BoardRow.js';
-import { Item } from '../../packages/react-components/src/Item.js';
 import { ListBox } from '../../packages/react-components/src/ListBox.js';
 import { RadioButton } from '../../packages/react-components/src/RadioButton.js';
 import { RadioGroup } from '../../packages/react-components/src/RadioGroup.js';
 import { RichTextEditor } from '../../packages/react-components-pro/src/RichTextEditor.js';
 import { Select } from '../../packages/react-components/src/Select.js';
+import { SelectItem } from '../../packages/react-components/src/SelectItem.js';
+import { SelectListBox } from '../../packages/react-components/src/SelectListBox.js';
 import { Tooltip } from '../../packages/react-components/src/Tooltip.js';
 
-function SelectListBox() {
+function SelectRenderer() {
   return (
-    <ListBox>
-      <Item value="1">One</Item>
-      <Item value="2">Two</Item>
-    </ListBox>
+    <SelectListBox>
+      <SelectItem value="1">One</SelectItem>
+      <SelectItem value="2">Two</SelectItem>
+    </SelectListBox>
   );
 }
 
@@ -29,7 +30,7 @@ export default function Row8() {
       </RadioGroup>
       <RichTextEditor></RichTextEditor>
       <Select label="Select" value="2">
-        {SelectListBox}
+        {SelectRenderer}
         <span slot="prefix">+</span>
         <Tooltip slot="tooltip" text="Select tooltip"></Tooltip>
       </Select>

--- a/dev/pages/Select.tsx
+++ b/dev/pages/Select.tsx
@@ -1,12 +1,12 @@
 import { Select } from '../../packages/react-components/src/Select.js';
-import type { SelectItem } from '../../packages/react-components/src/Select.js';
+import type { SelectItemData } from '../../packages/react-components/src/Select.js';
 import { ListBox } from '../../packages/react-components/src/ListBox.js';
 import { Item } from '../../packages/react-components/src/Item.js';
 import { Tooltip } from '../../packages/react-components/src/Tooltip.js';
 import { useEffect, useState } from 'react';
 import type { SelectInvalidChangedEvent, SelectValidatedEvent } from '@vaadin/select';
 
-const items: SelectItem[] = [
+const items: SelectItemData[] = [
   { label: 'Option 1', value: 'opt1' },
   { label: 'Option 2', value: 'opt2' },
   { component: 'hr' },

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -373,6 +373,14 @@
       "types": "./Select.d.ts",
       "default": "./Select.js"
     },
+    "./SelectItem.js": {
+      "types": "./SelectItem.d.ts",
+      "default": "./SelectItem.js"
+    },
+    "./SelectListBox.js": {
+      "types": "./SelectListBox.d.ts",
+      "default": "./SelectListBox.js"
+    },
     "./SideNav.js": {
       "types": "./SideNav.d.ts",
       "default": "./SideNav.js"
@@ -507,6 +515,8 @@
     "./RangeSlider": "./RangeSlider.js",
     "./Scroller": "./Scroller.js",
     "./Select": "./Select.js",
+    "./SelectItem": "./SelectItem.js",
+    "./SelectListBox": "./SelectListBox.js",
     "./SideNav": "./SideNav.js",
     "./SideNavItem": "./SideNavItem.js",
     "./Slider": "./Slider.js",

--- a/packages/react-components/src/SelectItem.ts
+++ b/packages/react-components/src/SelectItem.ts
@@ -1,0 +1,1 @@
+export * from './generated/SelectItem.js';

--- a/packages/react-components/src/SelectListBox.ts
+++ b/packages/react-components/src/SelectListBox.ts
@@ -1,0 +1,1 @@
+export * from './generated/SelectListBox.js';


### PR DESCRIPTION
## Description

Based on https://github.com/vaadin/web-components/pull/12132

Added `SelectItem` and `SelectListBox`.

## Type of change

- Feature

## Note

Dev page not updated yet as it fails due to missing `label` - needs https://github.com/vaadin/web-components/pull/12176.

```
[types]   Property 'label' does not exist on type 'IntrinsicAttributes & Partial<ThemedWebComponentProps<SelectItem, Readonly<{}>>> & RefAttributes<SelectItem>'.
[types]
[types] 124                   label={useItemLabelInCustomRenderer ? `${person.firstName} ${person.lastName}` : undefined}
[types]                       ~~~~~
```