### PR TITLE
fix!: resolve SelectItem barrel export collision in favor of the component

### DIFF
--- a/scripts/generator.ts
+++ b/scripts/generator.ts
@@ -419,7 +419,13 @@ const sourceFiles = Array.from(elementFilesMap.entries(), ([element, data]) => g
 const elementNames = sourceFiles.map(({ fileName }) => basename(fileName, '.ts'));
 
 function generateIndexFile(elementNames: readonly string[], extension: string): SourceFile {
-  const sourceLines = [...elementNames.map((elementName) => `export * from './${elementName}.js';`)];
+  const sourceLines = [
+    ...elementNames.map((elementName) => `export * from './${elementName}.js';`),
+    // Explicit re-exports beat star exports per-name in TypeScript, so these deterministically
+    // resolve each component name (e.g. `SelectItem`) even if another module's `export *` chain
+    // re-exports a colliding name (e.g. a deprecated type from a web component package).
+    ...elementNames.map((elementName) => `export { ${elementName} } from './${elementName}.js';`),
+  ];
 
   return ts.createSourceFile(
     resolve(packageDir, `index.${extension}`),

--- a/test/typings/SelectItem.tsx
+++ b/test/typings/SelectItem.tsx
@@ -1,0 +1,16 @@
+import { SelectItem, type SelectItemData } from '@vaadin/react-components';
+import type { SelectItem as SelectItemType } from '@vaadin/react-components/Select.js';
+
+// `SelectItem` must resolve to the React component and work in value/JSX position.
+const element = <SelectItem value="x">x</SelectItem>;
+
+// `SelectItemData` must still work in type position (unaffected by the collision fix).
+const items: SelectItemData[] = [];
+
+// The deprecated `SelectItem` type is intentionally no longer exported from the barrel;
+// `SelectItem` now refers only to the component, so using it as a type must fail to compile.
+// @ts-expect-error — `SelectItem` is a value (the component) in the barrel, not a type.
+let deprecated: SelectItem[];
+
+// Escape hatch: the deprecated type is still importable directly from the Select.js subpath.
+let stillWorks: SelectItemType[] = [];


### PR DESCRIPTION
## Problem

Since #390 added the `SelectItem` React component, the package barrel exports the name `SelectItem` twice via `export *` chains:

- `export * from "./SelectItem.js"` → the new React component (value)
- `export * from "./Select.js"` → `export * from "@vaadin/select/vaadin-select.js"` → the deprecated `type SelectItem = SelectItemData` alias (deprecated in vaadin/web-components#12132)

TypeScript resolves the duplicated name to the *first* star export, so `SelectItem` in type position now fails in consumer projects:

```
error TS2749: 'SelectItem' refers to a value, but is being used as a type here.
```

Resolution was also order-dependent (barrel line order follows schema-discovery order), so a reordering could have silently broken the component import instead. The repo's own `validate:types` never catches this because the barrel is emitted directly as `index.d.ts`/`index.js` and never compiled as source.

## Change

- The generated barrel now emits an explicit `export { X } from './X.js';` per component after the star exports. Explicit exports beat star exports per-name, so each component name deterministically resolves to the component, independent of barrel order.
- Added a type-level regression fixture (`test/typings/SelectItem.tsx`, compiled by `validate:types`) asserting: `SelectItem` works as a JSX component from the barrel, `SelectItemData` works in type position, `SelectItem` in type position is an error, and the deprecated type remains importable from `@vaadin/react-components/Select.js`.

`SelectItemData` was already re-exported transitively and keeps working unchanged; docs examples were migrated in vaadin/docs#5831. Runtime is unaffected — the collision was type-only.

## BREAKING CHANGE

The deprecated TypeScript type `SelectItem` is no longer exported from the package barrel; use `SelectItemData` instead, or import the deprecated type from `@vaadin/react-components/Select.js`. `SelectItem` now refers to the React component. (In practice this break already shipped with 25.3.0-alpha6, where the component shadowed the type — this change makes the resolution deterministic and documented.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)